### PR TITLE
BASW-17: Fixing of contribution processing with no payment processor

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2520,6 +2520,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     $template = $this->_assignMessageVariablesToTemplate($values, $input, $returnMessageText);
+    $paymentObject = NULL;
     //what does recur 'mean here - to do with payment processor return functionality but
     // what is the importance
     if (!empty($this->contribution_recur_id) && !empty($this->_relatedObjects['paymentProcessor'])) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2397,7 +2397,20 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $ids
     ));
 
-    if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id) {
+    $ids['contributionType'] = $this->financial_type_id;
+    $ids['financialType'] = $this->financial_type_id;
+    if ($this->contribution_page_id) {
+      $ids['contributionPage'] = $this->contribution_page_id;
+    }
+    $this->loadRelatedEntitiesByID($ids);
+
+    $recurPaymentProcessor = FALSE;
+    if (!empty($this->_relatedObjects['contributionRecur']) && !$paymentProcessorID) {
+      $recurPaymentProcessor = TRUE;
+      $paymentProcessorID = $this->_relatedObjects['contributionRecur']->payment_processor_id;
+    }
+
+    if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id && !$recurPaymentProcessor) {
       $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',
         $this->contribution_page_id,
         'payment_processor'
@@ -2405,18 +2418,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if ($paymentProcessorID) {
         $intentionalEnotice = $CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage;
       }
-    }
-
-    $ids['contributionType'] = $this->financial_type_id;
-    $ids['financialType'] = $this->financial_type_id;
-    if ($this->contribution_page_id) {
-      $ids['contributionPage'] = $this->contribution_page_id;
-    }
-
-    $this->loadRelatedEntitiesByID($ids);
-
-    if (!empty($ids['contributionRecur']) && !$paymentProcessorID) {
-      $paymentProcessorID = $this->_relatedObjects['contributionRecur']->payment_processor_id;
     }
 
     if (!empty($ids['pledge_payment'])) {


### PR DESCRIPTION
This PR provides a handling empty Payment Processor within Contribution BAO's loadRelatedObjects() method. Without the changes we got this set of PHP notices for each Recipe email sent on webform submission:

-----------------------------------------------------
Notice: Undefined variable: CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage in CRM_Contribute_BAO_Contribution->loadRelatedObjects() (line 2406 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Contribute/BAO/Contribution.php).

Notice: Undefined offset: 1 in CRM_Financial_BAO_PaymentProcessor::getPayment() (line 221 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Financial/BAO/PaymentProcessor.php).

Notice: Undefined index: payment_processor_type_id in CRM_Financial_BAO_PaymentProcessor::getPayment() (line 248 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Financial/BAO/PaymentProcessor.php).

Notice: Undefined offset: 1 in CRM_Financial_BAO_PaymentProcessor::getPayment() (line 249 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Financial/BAO/PaymentProcessor.php).

Notice: Undefined offset: 1 in CRM_Financial_BAO_PaymentProcessor::getPayment() (line 221 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Financial/BAO/PaymentProcessor.php).

Notice: Undefined index: payment_processor_type_id in CRM_Financial_BAO_PaymentProcessor::getPayment() (line 248 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Financial/BAO/PaymentProcessor.php).

Notice: Undefined offset: 1 in CRM_Financial_BAO_PaymentProcessor::getPayment() (line 249 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Financial/BAO/PaymentProcessor.php).

Notice: Undefined variable: paymentObject in CRM_Contribute_BAO_Contribution->composeMessageArray() (line 2638 of /home/casterama/www/basw-21/sites/all/modules/civicrm/CRM/Contribute/BAO/Contribution.php).

-----------------------------------------------------

The goal was to accept Payment Processor ID as NULL (which is valid value for payment processor when using Recurring Contribution and offline payment). Previously a NULL value was treated like an incorrect value for Recurring Contribution.

I added a conditional block checking for Payment Processor within Recurring Contribution object (and marking $recurPaymentProcessor if the value is found there - because we can't rely on $paymentProcessorID which now CAN be NULL even if it's found).

I moved "$CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage" conditional block to the bottom because it seems that any "Unreliable" assignment should be done last.

Additionally, I added "$paymentObject = NULL" declaration to get rid of "Undefined variable $paymentObject" Notice message.


Now the code works fine without any Notice messages. But there are still **two questions before implementing these changes into the workstream**:

Question 1:
This class contains 'composeMessageArray()' method which builds a Receipt's mail content (per Contribution). It defines some links such as 'cancelSubscriptionUrl' - which are reasonable for online Recurring Contribution. What about these links in our case (Recurring Contribution with offline payment)?
Is 'cancel subscription' link still needed to put it into the Receipt email content?

Question 2:
The crazy "$CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage" variable. Looking into the code it seems that this variable was put there purposely (to cause a PHP Notice saying that's we've picked up a Payment Processor from Contribution Page). This attempt may be reasonable but looks weird and I guess it should be changed or removed.

There is also a similar variable several lines below, it's called "$CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromEvent".
The comment at it says:
"Get the payment processor id from event - this is inaccurate see CRM-16923.
In future we should look at throwing an exception here rather than an dubious guess."

The question is - do we want to do anything with such code within BASW-17 scope?