### PR TITLE
PCHR-3467: Add default assignee options

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveZero.php
+++ b/CRM/Upgrade/Incremental/php/FiveZero.php
@@ -72,7 +72,9 @@ class CRM_Upgrade_Incremental_php_FiveZero extends CRM_Upgrade_Incremental_Base 
   }
 
   /**
-   * Upgrade function.
+   * Upgrade function for version 5.0.1. This version adds the default assignee
+   * option values that can be selected when creating or editing a new
+   * workflow's activity.
    *
    * @param string $rev
    */

--- a/CRM/Upgrade/Incremental/php/FiveZero.php
+++ b/CRM/Upgrade/Incremental/php/FiveZero.php
@@ -71,6 +71,48 @@ class CRM_Upgrade_Incremental_php_FiveZero extends CRM_Upgrade_Incremental_Base 
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
   }
 
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_0_1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+
+    // Add option group for activity default assignees:
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(array(
+      'name' => 'activity_default_assignee',
+      'title' => ts('Activity default assignee'),
+      'is_reserved' => 1,
+    ));
+
+    // Add option values for activity default assignees:
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+      'option_group_id' => 'activity_default_assignee',
+      'name' => 'NONE',
+      'label' => ts('None'),
+      'is_active' => TRUE
+    ));
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+      'option_group_id' => 'activity_default_assignee',
+      'name' => 'BY_RELATIONSHIP',
+      'label' => ts('By relationship to case client'),
+      'is_active' => TRUE
+    ));
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+      'option_group_id' => 'activity_default_assignee',
+      'name' => 'SPECIFIC_CONTACT',
+      'label' => ts('Specific contact'),
+      'is_active' => TRUE
+    ));
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+      'option_group_id' => 'activity_default_assignee',
+      'name' => 'USER_CREATING_THE_CASE',
+      'label' => ts('User creating the case'),
+      'is_active' => TRUE
+    ));
+  }
+
   /*
    * Important! All upgrade functions MUST add a 'runSql' task.
    * Uncomment and use the following template for a new upgrade version

--- a/CRM/Upgrade/Incremental/php/FiveZero.php
+++ b/CRM/Upgrade/Incremental/php/FiveZero.php
@@ -87,30 +87,21 @@ class CRM_Upgrade_Incremental_php_FiveZero extends CRM_Upgrade_Incremental_Base 
     ));
 
     // Add option values for activity default assignees:
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
-      'option_group_id' => 'activity_default_assignee',
-      'name' => 'NONE',
-      'label' => ts('None'),
-      'is_active' => TRUE
-    ));
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
-      'option_group_id' => 'activity_default_assignee',
-      'name' => 'BY_RELATIONSHIP',
-      'label' => ts('By relationship to case client'),
-      'is_active' => TRUE
-    ));
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
-      'option_group_id' => 'activity_default_assignee',
-      'name' => 'SPECIFIC_CONTACT',
-      'label' => ts('Specific contact'),
-      'is_active' => TRUE
-    ));
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
-      'option_group_id' => 'activity_default_assignee',
-      'name' => 'USER_CREATING_THE_CASE',
-      'label' => ts('User creating the case'),
-      'is_active' => TRUE
-    ));
+    $options = array(
+      array('name' => 'NONE', 'label' => ts('None')),
+      array('name' => 'BY_RELATIONSHIP', 'label' => ts('By relationship to case client')),
+      array('name' => 'SPECIFIC_CONTACT', 'label' => ts('Specific contact')),
+      array('name' => 'USER_CREATING_THE_CASE', 'label' => ts('User creating the case'))
+    );
+
+    foreach ($options as $option) {
+      CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+        'option_group_id' => 'activity_default_assignee',
+        'name' => $option['name'],
+        'label' => $option['label'],
+        'is_active' => TRUE
+      ));
+    }
   }
 
   /*

--- a/CRM/Upgrade/Incremental/sql/5.0.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.0.1.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.0.1 during upgrade *}

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -170,8 +170,8 @@
       } else {
         // new case type
         $scope.caseType = _.cloneDeep(newCaseTypeTemplate);
-        $scope.caseType.definition.activitySets[0].activityTypes[0]
-        .default_assignee_type = $scope.defaultAssigneeTypesIndex.NONE.id;
+        $scope.caseType.definition.activitySets[0].activityTypes[0].default_assignee_type =
+          $scope.defaultAssigneeTypesIndex.NONE.id;
       }
     }
 

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -180,18 +180,20 @@
       $scope.caseType.definition = $scope.caseType.definition || [];
       $scope.caseType.definition.activityTypes = $scope.caseType.definition.activityTypes || [];
       $scope.caseType.definition.activitySets = $scope.caseType.definition.activitySets || [];
+      $scope.caseType.definition.caseRoles = $scope.caseType.definition.caseRoles || [];
+      $scope.caseType.definition.statuses = $scope.caseType.definition.statuses || [];
+
       _.each($scope.caseType.definition.activitySets, function (set) {
         _.each(set.activityTypes, function (type, name) {
           type.label = $scope.activityTypes[type.name].label;
         });
       });
-      $scope.caseType.definition.caseRoles = $scope.caseType.definition.caseRoles || [];
-      $scope.caseType.definition.statuses = $scope.caseType.definition.statuses || [];
     }
 
     /// initializes the selected statuses
     function initSelectedStatuses() {
       $scope.selectedStatuses = {};
+
       _.each(apiCalls.caseStatuses.values, function (status) {
         $scope.selectedStatuses[status.name] = !$scope.caseType.definition.statuses.length || $scope.caseType.definition.statuses.indexOf(status.name) > -1;
       });

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -239,6 +239,12 @@
       }
     };
 
+    /// Clears the activity's default assignee values for relationship and contact
+    $scope.clearActivityDefaultAssigneeValues = function(activity) {
+      activity.default_assignee_relationship = null;
+      activity.default_assignee_contact = null;
+    };
+
     /// Add a new role
     $scope.addRole = function(roles, roleName) {
       var names = _.pluck($scope.caseType.definition.caseRoles, 'name');

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -67,6 +67,13 @@
                 limit: 0
               }
             }];
+            reqs.defaultAssigneeTypes = ['OptionValue', 'get', {
+              option_group_id: 'activity_default_assignee',
+              sequential: 1,
+              options: {
+                limit: 0
+              }
+            }];
             reqs.relTypes = ['RelationshipType', 'get', {
               sequential: 1,
               options: {
@@ -135,6 +142,8 @@
     $scope.caseStatuses = _.indexBy(apiCalls.caseStatuses.values, 'name');
     $scope.activityTypes = _.indexBy(apiCalls.actTypes.values, 'name');
     $scope.activityTypeOptions = _.map(apiCalls.actTypes.values, formatActivityTypeOption);
+    $scope.defaultAssigneeTypes = apiCalls.defaultAssigneeTypes.values;
+    $scope.defaultAssigneeTypesIndex = _.indexBy(apiCalls.defaultAssigneeTypes.values, 'name');
     $scope.relationshipTypeOptions = _.map(apiCalls.relTypes.values, function(type) {
       return {id: type[REL_TYPE_CNAME], text: type.label_b_a};
     });

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -154,7 +154,16 @@
       'sequence': 'Sequence'
     };
 
-    $scope.caseType = apiCalls.caseType ? apiCalls.caseType : _.cloneDeep(newCaseTypeTemplate);
+    if (apiCalls.caseType) {
+      // edit case type
+      $scope.caseType = apiCalls.caseType;
+    } else {
+      // new case type
+      $scope.caseType = _.cloneDeep(newCaseTypeTemplate);
+      $scope.caseType.definition.activitySets[0].activityTypes[0]
+        .default_assignee_type = $scope.defaultAssigneeTypesIndex.NONE.id;
+    }
+
     $scope.caseType.definition = $scope.caseType.definition || [];
     $scope.caseType.definition.activityTypes = $scope.caseType.definition.activityTypes || [];
     $scope.caseType.definition.activitySets = $scope.caseType.definition.activitySets || [];

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -133,52 +133,69 @@
   });
 
   crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls) {
-    // CRM_Case_XMLProcessor::REL_TYPE_CNAME
-    var REL_TYPE_CNAME = CRM.crmCaseType.REL_TYPE_CNAME,
+    var REL_TYPE_CNAME, ts;
 
-    ts = $scope.ts = CRM.ts(null);
+    (function init () {
+      // CRM_Case_XMLProcessor::REL_TYPE_CNAME
+      REL_TYPE_CNAME = CRM.crmCaseType.REL_TYPE_CNAME,
 
-    $scope.activityStatuses = apiCalls.actStatuses.values;
-    $scope.caseStatuses = _.indexBy(apiCalls.caseStatuses.values, 'name');
-    $scope.activityTypes = _.indexBy(apiCalls.actTypes.values, 'name');
-    $scope.activityTypeOptions = _.map(apiCalls.actTypes.values, formatActivityTypeOption);
-    $scope.defaultAssigneeTypes = apiCalls.defaultAssigneeTypes.values;
-    $scope.defaultAssigneeTypesIndex = _.indexBy(apiCalls.defaultAssigneeTypes.values, 'name');
-    $scope.relationshipTypeOptions = _.map(apiCalls.relTypes.values, function(type) {
-      return {id: type[REL_TYPE_CNAME], text: type.label_b_a};
-    });
-    $scope.locks = {caseTypeName: true, activitySetName: true};
+      ts = $scope.ts = CRM.ts(null);
+      $scope.locks = { caseTypeName: true, activitySetName: true };
+      $scope.workflows = { timeline: 'Timeline', sequence: 'Sequence' };
 
-    $scope.workflows = {
-      'timeline': 'Timeline',
-      'sequence': 'Sequence'
-    };
+      storeApiCallsResults();
+      initCaseType();
+      initCaseTypeDefinition();
+      initSelectedStatuses();
+    })();
 
-    if (apiCalls.caseType) {
-      // edit case type
-      $scope.caseType = apiCalls.caseType;
-    } else {
-      // new case type
-      $scope.caseType = _.cloneDeep(newCaseTypeTemplate);
-      $scope.caseType.definition.activitySets[0].activityTypes[0]
-        .default_assignee_type = $scope.defaultAssigneeTypesIndex.NONE.id;
+    /// Stores the api calls results in the $scope object
+    function storeApiCallsResults() {
+      $scope.activityStatuses = apiCalls.actStatuses.values;
+      $scope.caseStatuses = _.indexBy(apiCalls.caseStatuses.values, 'name');
+      $scope.activityTypes = _.indexBy(apiCalls.actTypes.values, 'name');
+      $scope.activityTypeOptions = _.map(apiCalls.actTypes.values, formatActivityTypeOption);
+      $scope.defaultAssigneeTypes = apiCalls.defaultAssigneeTypes.values;
+      $scope.defaultAssigneeTypesIndex = _.indexBy($scope.defaultAssigneeTypes, 'name');
+      $scope.relationshipTypeOptions = _.map(apiCalls.relTypes.values, function(type) {
+        return {id: type[REL_TYPE_CNAME], text: type.label_b_a};
+      });
     }
 
-    $scope.caseType.definition = $scope.caseType.definition || [];
-    $scope.caseType.definition.activityTypes = $scope.caseType.definition.activityTypes || [];
-    $scope.caseType.definition.activitySets = $scope.caseType.definition.activitySets || [];
-    _.each($scope.caseType.definition.activitySets, function (set) {
-      _.each(set.activityTypes, function (type, name) {
-        type.label = $scope.activityTypes[type.name].label;
-      });
-    });
-    $scope.caseType.definition.caseRoles = $scope.caseType.definition.caseRoles || [];
-    $scope.caseType.definition.statuses = $scope.caseType.definition.statuses || [];
+    /// initializes the case type object
+    function initCaseType() {
+      if (apiCalls.caseType) {
+        // edit case type
+        $scope.caseType = apiCalls.caseType;
+      } else {
+        // new case type
+        $scope.caseType = _.cloneDeep(newCaseTypeTemplate);
+        $scope.caseType.definition.activitySets[0].activityTypes[0]
+        .default_assignee_type = $scope.defaultAssigneeTypesIndex.NONE.id;
+      }
+    }
 
-    $scope.selectedStatuses = {};
-    _.each(apiCalls.caseStatuses.values, function (status) {
-      $scope.selectedStatuses[status.name] = !$scope.caseType.definition.statuses.length || $scope.caseType.definition.statuses.indexOf(status.name) > -1;
-    });
+    /// initializes the case type definition object
+    function initCaseTypeDefinition() {
+      $scope.caseType.definition = $scope.caseType.definition || [];
+      $scope.caseType.definition.activityTypes = $scope.caseType.definition.activityTypes || [];
+      $scope.caseType.definition.activitySets = $scope.caseType.definition.activitySets || [];
+      _.each($scope.caseType.definition.activitySets, function (set) {
+        _.each(set.activityTypes, function (type, name) {
+          type.label = $scope.activityTypes[type.name].label;
+        });
+      });
+      $scope.caseType.definition.caseRoles = $scope.caseType.definition.caseRoles || [];
+      $scope.caseType.definition.statuses = $scope.caseType.definition.statuses || [];
+    }
+
+    /// initializes the selected statuses
+    function initSelectedStatuses() {
+      $scope.selectedStatuses = {};
+      _.each(apiCalls.caseStatuses.values, function (status) {
+        $scope.selectedStatuses[status.name] = !$scope.caseType.definition.statuses.length || $scope.caseType.definition.statuses.indexOf(status.name) > -1;
+      });
+    }
 
     $scope.addActivitySet = function(workflow) {
       var activitySet = {};

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -199,7 +199,8 @@
         status: 'Scheduled',
         reference_activity: 'Open Case',
         reference_offset: '1',
-        reference_select: 'newest'
+        reference_select: 'newest',
+        default_assignee_type: $scope.defaultAssigneeTypesIndex.NONE.id
       });
     }
 

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -11,6 +11,7 @@ Required vars: activitySet
     <th>{{ts('Reference')}}</th>
     <th>{{ts('Offset')}}</th>
     <th>{{ts('Select')}}</th>
+    <th>{{ts('Default assignee')}}</th>
     <th></th>
   </tr>
   </thead>
@@ -60,6 +61,35 @@ Required vars: activitySet
         ng-options="key as value for (key,value) in {newest: ts('Newest'), oldest: ts('Oldest')}"
         >
       </select>
+    </td>
+    <td>
+      <select
+        ui-jq="select2"
+        ui-options="{dropdownAutoWidth : true}"
+        ng-model="activity.default_assignee_type"
+        ng-options="option.id as option.label for option in defaultAssigneeTypes"
+        ng-change="clearActivityDefaultAssigneeValues(activity)"
+      ></select>
+
+      <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.BY_RELATIONSHIP.id">
+        <select
+          ui-jq="select2"
+          ui-options="{dropdownAutoWidth : true}"
+          ng-model="activity.default_assignee_relationship"
+          ng-options="option as option.text for option in relationshipTypeOptions"
+          required
+        ></select>
+      </p>
+
+      <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.SPECIFIC_CONTACT.id">
+        <input
+          type="text"
+          ng-model="activity.default_assignee_contact"
+          placeholder="- select contact -"
+          crm-entityref="{ entity: 'Contact' }"
+          data-create-links="true"
+          required />
+      </p>
     </td>
     <td>
       <a class="crm-hover-button"

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -28,7 +28,7 @@ Required vars: activitySet
     <td>
       <select
         ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        ui-options="{ dropdownAutoWidth: true }"
         ng-model="activity.status"
         ng-options="actStatus.name as actStatus.label for actStatus in activityStatuses|orderBy:'label'"
         >
@@ -38,7 +38,7 @@ Required vars: activitySet
     <td>
       <select
         ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        ui-options="{ dropdownAutoWidth: true }"
         ng-model="activity.reference_activity"
         ng-options="activityType.name as activityType.label for activityType in activitySet.activityTypes"
         >
@@ -56,7 +56,7 @@ Required vars: activitySet
     <td>
       <select
         ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        ui-options="{ dropdownAutoWidth: true }"
         ng-model="activity.reference_select"
         ng-options="key as value for (key,value) in {newest: ts('Newest'), oldest: ts('Oldest')}"
         >
@@ -65,7 +65,7 @@ Required vars: activitySet
     <td>
       <select
         ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        ui-options="{ dropdownAutoWidth: true }"
         ng-model="activity.default_assignee_type"
         ng-options="option.id as option.label for option in defaultAssigneeTypes"
         ng-change="clearActivityDefaultAssigneeValues(activity)"
@@ -74,7 +74,7 @@ Required vars: activitySet
       <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.BY_RELATIONSHIP.id">
         <select
           ui-jq="select2"
-          ui-options="{dropdownAutoWidth : true}"
+          ui-options="{ dropdownAutoWidth: true }"
           ng-model="activity.default_assignee_relationship"
           ng-options="option as option.text for option in relationshipTypeOptions"
           required
@@ -85,7 +85,7 @@ Required vars: activitySet
         <input
           type="text"
           ng-model="activity.default_assignee_contact"
-          placeholder="- select contact -"
+          placeholder="- Select contact -"
           crm-entityref="{ entity: 'Contact' }"
           data-create-links="true"
           required />

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -104,7 +104,7 @@ Required vars: activitySet
 
   <tfoot>
   <tr class="addRow">
-    <td colspan="6">
+    <td colspan="8">
       <span crm-add-name=""
            crm-options="activityTypeOptions"
            crm-var="newActivity"

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -318,5 +318,25 @@ describe('crmCaseType', function() {
       expect(newSet.label).toBe('Timeline #2');
     });
 
+    describe('when clearing the activity\'s default assignee type values', function() {
+      var activity;
+
+      beforeEach(function() {
+        activity = {
+          default_assignee_relationship: 1,
+          default_assignee_contact: 2
+        };
+
+        scope.clearActivityDefaultAssigneeValues(activity);
+      });
+
+      it('clears the default assignee relationship for the activity', function() {
+        expect(activity.default_assignee_relationship).toBe(null);
+      });
+
+      it('clears the default assignee contact for the activity', function() {
+        expect(activity.default_assignee_contact).toBe(null);
+      });
+    });
   });
 });

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -338,5 +338,28 @@ describe('crmCaseType', function() {
         expect(activity.default_assignee_contact).toBe(null);
       });
     });
+
+    describe('when adding a new activity to a set', function() {
+      var activitySet;
+
+      beforeEach(function() {
+        activitySet = { activityTypes: [] };
+        scope.activityTypes = { comment: { label: 'Add a new comment' } };
+
+        scope.addActivity(activitySet, 'comment');
+      });
+
+      it('adds a new Comment activity to the set', function() {
+        expect(activitySet.activityTypes[0]).toEqual({
+          name: 'comment',
+          label: scope.activityTypes.comment.label,
+          status: 'Scheduled',
+          reference_activity: 'Open Case',
+          reference_offset: '1',
+          reference_select: 'newest',
+          default_assignee_type: scope.defaultAssigneeTypesIndex.NONE.id
+        });
+      });
+    });
   });
 });

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -361,5 +361,30 @@ describe('crmCaseType', function() {
         });
       });
     });
+
+    describe('when creating a new workflow', function() {
+      beforeEach(inject(function ($controller) {
+        apiCalls.caseType = null;
+
+        ctrl = $controller('CaseTypeCtrl', {$scope: scope, apiCalls: apiCalls});
+      }));
+
+      it('sets default values for the case type title, name, and active status', function() {
+        expect(scope.caseType).toEqual(jasmine.objectContaining({
+          title: '',
+          name: '',
+          is_active: '1'
+        }));
+      });
+
+      it('adds an Open Case activty to the default activty set', function() {
+        expect(scope.caseType.definition.activitySets[0].activityTypes).toEqual([{
+          name: 'Open Case',
+          label: 'Open Case',
+          status: 'Completed',
+          default_assignee_type: scope.defaultAssigneeTypesIndex.NONE.id
+        }]);
+      });
+    });
   });
 });

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -222,6 +222,62 @@ describe('crmCaseType', function() {
               }
             ]
           }
+        },
+        defaultAssigneeTypes: {
+          values: [
+              {
+                "id": "1174",
+                "option_group_id": "152",
+                "label": "None",
+                "value": "1",
+                "name": "NONE",
+                "filter": "0",
+                "is_default": "0",
+                "weight": "1",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              },
+              {
+                "id": "1175",
+                "option_group_id": "152",
+                "label": "By relationship to workflow client",
+                "value": "2",
+                "name": "BY_RELATIONSHIP",
+                "filter": "0",
+                "is_default": "0",
+                "weight": "2",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              },
+              {
+                "id": "1176",
+                "option_group_id": "152",
+                "label": "Specific contact",
+                "value": "3",
+                "name": "SPECIFIC_CONTACT",
+                "filter": "0",
+                "is_default": "0",
+                "weight": "3",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              },
+              {
+                "id": "1177",
+                "option_group_id": "152",
+                "label": "User creating the workflow",
+                "value": "4",
+                "name": "USER_CREATING_THE_CASE",
+                "filter": "0",
+                "is_default": "0",
+                "weight": "4",
+                "is_optgroup": "0",
+                "is_reserved": "0",
+                "is_active": "1"
+              }
+          ]
         }
       };
       ctrl = $controller('CaseTypeCtrl', {$scope: scope, apiCalls: apiCalls});
@@ -233,6 +289,14 @@ describe('crmCaseType', function() {
 
     it('should load activity types', function() {
       expect(scope.activityTypes['ADC referral']).toEqualData(apiCalls.actTypes.values[0]);
+    });
+
+    it('should store the default assignee types', function() {
+      expect(scope.defaultAssigneeTypes).toBe(apiCalls.defaultAssigneeTypes.values);
+    });
+
+    it('should store the default assignee types indexed by name', function() {
+      expect(scope.defaultAssigneeTypesIndex).toEqual(_.indexBy(apiCalls.defaultAssigneeTypes.values, 'name'));
     });
 
     it('addActivitySet should add an activitySet to the case type', function() {

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.0.0</version_no>
+  <version_no>5.0.1</version_no>
 </version>


### PR DESCRIPTION
## Description

This PR adds the default assignee options to the CiviCRM's Activity Form in the Workflow section

## Before
![exiting hr17 9000](https://user-images.githubusercontent.com/1642119/37577054-f4e079be-2b05-11e8-8d8d-447a592e9137.png)


## After
![anim](https://user-images.githubusercontent.com/1642119/37576991-a103e844-2b05-11e8-9644-8d9810255173.gif)
* When *By relationship to case client* is chosen, a relationship picker is displayed.
* When *Specific contact* is chosen, a contact picker is displayed.
* When *None* or *User creating the case* is chosen, no other field is shown.

## Technical Details

### Inserting the default assignee options in the database

A new upgrader was added targeting version 5.0.1, a hypothetical version that branches off from 5.0.0, which is a new version in development. The upgrader reads as follows:

```php
public function upgrade_5_0_1($rev) {
  $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
  // Add option group for activity default assignees:
  CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(array(
    'name' => 'activity_default_assignee',
    'title' => ts('Activity default assignee'),
    'is_reserved' => 1,
  ));
  // Add option values for activity default assignees:
  CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
    'option_group_id' => 'activity_default_assignee',
    'name' => 'NONE',
    'label' => ts('None'),
    'is_active' => TRUE
  ));
  CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
    'option_group_id' => 'activity_default_assignee',
    'name' => 'BY_RELATIONSHIP',
    'label' => ts('By relationship to case client'),
    'is_active' => TRUE
  ));
  CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
    'option_group_id' => 'activity_default_assignee',
    'name' => 'SPECIFIC_CONTACT',
    'label' => ts('Specific contact'),
    'is_active' => TRUE
  ));
  CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
    'option_group_id' => 'activity_default_assignee',
    'name' => 'USER_CREATING_THE_CASE',
    'label' => ts('User creating the case'),
    'is_active' => TRUE
  ));
}
```

The `$this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);` is required to be defined by all upgraders according to [this comment](https://github.com/compucorp/civicrm-core/blob/ab71b8c6bb9990e72d7179e58d3b67520dce46ef/CRM/Upgrade/Incremental/php/FiveZero.php#L117). This also means we need to add an "empty"  [5.0.1.mysql.tpl](https://github.com/compucorp/civicrm-core/pull/12/files#diff-fd2ae54dae4ff5e3f1619ba6a1e5d5e1R1) file.

### Displaying the default assignee options

The default assignee options are requested in the `apiCalls` for the `CaseTypeCtrl` controller:

```js
$routeProvider.when('/caseType/:id', {
  // ...
  controller: 'CaseTypeCtrl',
  resolve: {
    apiCalls: function($route, crmApi) {
      var reqs = {};
      // ...

      reqs.defaultAssigneeTypes = ['OptionValue', 'get', {
        option_group_id: 'activity_default_assignee',
        sequential: 1,
        options: {
          limit: 0
        }
      }];

      // ...
    }
  }
});

crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls) {
  // ...
  $scope.defaultAssigneeTypes = apiCalls.defaultAssigneeTypes.values;
  // this index is used to determine which option was chosen and to display companion fields accordingly:
  $scope.defaultAssigneeTypesIndex = _.indexBy(apiCalls.defaultAssigneeTypes.values, 'name');
  // ...
});
```

The fields are displayed in the form by editing the `timelineTable.html` as this:

```html
<td>
  <select
    ui-jq="select2"
    ui-options="{dropdownAutoWidth : true}"
    ng-model="activity.default_assignee_type"
    ng-options="option.id as option.label for option in defaultAssigneeTypes"
    ng-change="clearActivityDefaultAssigneeValues(activity)"
  ></select>

  <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.BY_RELATIONSHIP.id">
    <select
      ui-jq="select2"
      ui-options="{dropdownAutoWidth : true}"
      ng-model="activity.default_assignee_relationship"
      ng-options="option as option.text for option in relationshipTypeOptions"
      required
    ></select>
  </p>

  <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.SPECIFIC_CONTACT.id">
    <input
      type="text"
      ng-model="activity.default_assignee_contact"
      placeholder="- select contact -"
      crm-entityref="{ entity: 'Contact' }"
      data-create-links="true"
      required />
  </p>
</td>
```

Finally, the for new cases the default assignee is set to NONE:

```js
if (apiCalls.caseType) {
  // edit case type
  $scope.caseType = apiCalls.caseType;
} else {
  // new case type
  $scope.caseType = _.cloneDeep(newCaseTypeTemplate);
  $scope.caseType.definition.activitySets[0].activityTypes[0]
    .default_assignee_type = $scope.defaultAssigneeTypesIndex.NONE.id;
}
```

For JS files no lint rules or styleguide were followed since it doesn't seem this is the norm in CiviCRM-core. In turn this PR tries to follow a similar structure to what was already in place.

## Tests

JS unit tests were added for these changes. A few missing tests for the `ang/crmCaseType.js` file were added and the suit runs successfully.

* Note: some tests seem to be failing but they are not related to this PR,since they fail even when run from master.

