### PR TITLE
PCHR-3468: Select default assignee for activities

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -627,7 +627,11 @@ AND        a.is_deleted = 0
       'sequential' => 1
     ));
 
-    return $relationships['values'][0]['contact_id_a'];
+    if ($relationships['count']) {
+      return $relationships['values'][0]['contact_id_a'];
+    } else {
+      return NULL;
+    }
   }
 
   /**

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -587,6 +587,9 @@ AND        a.is_deleted = 0
       case $defaultAssigneeOptionsIds['SPECIFIC_CONTACT']:
         return $this->getDefaultAssigneeBySpecificContact($activityTypeXML);
         break;
+      case $defaultAssigneeOptionsIds['USER_CREATING_THE_CASE']:
+        return $activityParams['source_contact_id'];
+        break;
       default:
         return null;
     }

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -631,13 +631,17 @@ AND        a.is_deleted = 0
    * @return int|null the ID of the default assignee contact or null if none.
    */
   protected function getDefaultAssigneeByRelationship($activityParams, $activityTypeXML) {
+    if (!isset($activityTypeXML->default_assignee_relationship)) {
+      return NULL;
+    }
+
     $targetContactId = is_array($activityParams['target_contact_id'])
       ? $activityParams['target_contact_id'][0]
       : $activityParams['target_contact_id'];
 
     $relationships = civicrm_api3('Relationship', 'get', array(
       'contact_id_b' => $targetContactId,
-      'relationship_type_id' => $activityTypeXML->default_assignee_relationship,
+      'relationship_type_id.name' => $activityTypeXML->default_assignee_relationship,
       'sequential' => 1
     ));
 

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -31,7 +31,7 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
-  protected $defaultAssigneeOptionsIds = array();
+  protected $defaultAssigneeOptionsValues = [];
 
   /**
    * Run.
@@ -584,19 +584,19 @@ AND        a.is_deleted = 0
       return NULL;
     }
 
-    $defaultAssigneeOptionsIds = $this->getDefaultAssigneeOptionIds();
+    $defaultAssigneeOptionsValues = $this->getDefaultAssigneeOptionValues();
 
     switch($activityTypeXML->default_assignee_type) {
-      case $defaultAssigneeOptionsIds['BY_RELATIONSHIP']:
+      case $defaultAssigneeOptionsValues['BY_RELATIONSHIP']:
         return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML);
         break;
-      case $defaultAssigneeOptionsIds['SPECIFIC_CONTACT']:
+      case $defaultAssigneeOptionsValues['SPECIFIC_CONTACT']:
         return $this->getDefaultAssigneeBySpecificContact($activityTypeXML);
         break;
-      case $defaultAssigneeOptionsIds['USER_CREATING_THE_CASE']:
+      case $defaultAssigneeOptionsValues['USER_CREATING_THE_CASE']:
         return $activityParams['source_contact_id'];
         break;
-      case $defaultAssigneeOptionsIds['NONE']:
+      case $defaultAssigneeOptionsValues['NONE']:
       default:
         return NULL;
     }
@@ -607,9 +607,9 @@ AND        a.is_deleted = 0
    *
    * @return array
    */
-  protected function getDefaultAssigneeOptionIds() {
-    if (!empty($this->defaultAssigneeOptionsIds)) {
-      return $this->defaultAssigneeOptionsIds;
+  protected function getDefaultAssigneeOptionValues() {
+    if (!empty($this->defaultAssigneeOptionsValues)) {
+      return $this->defaultAssigneeOptionsValues;
     }
 
     $defaultAssigneeOptions =  civicrm_api3('OptionValue', 'get', [
@@ -618,10 +618,10 @@ AND        a.is_deleted = 0
     ]);
 
     foreach($defaultAssigneeOptions['values'] as $option) {
-      $this->defaultAssigneeOptionsIds[$option['name']] = $option['id'];
+      $this->defaultAssigneeOptionsValues[$option['name']] = $option['value'];
     }
 
-    return $this->defaultAssigneeOptionsIds;
+    return $this->defaultAssigneeOptionsValues;
   }
 
   /**

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -578,6 +578,10 @@ AND        a.is_deleted = 0
    * @return int|null the ID of the default assignee contact or null if none.
    */
   protected function getDefaultAssigneeForActivity($activityParams, $activityTypeXML) {
+    if (!isset($activityTypeXML->default_assignee_type)) {
+      return NULL;
+    }
+
     $defaultAssigneeOptionsIds = $this->getDefaultAssigneeOptionIds();
 
     switch($activityTypeXML->default_assignee_type) {
@@ -590,6 +594,7 @@ AND        a.is_deleted = 0
       case $defaultAssigneeOptionsIds['USER_CREATING_THE_CASE']:
         return $activityParams['source_contact_id'];
         break;
+      case $defaultAssigneeOptionsIds['NONE']:
       default:
         return null;
     }

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -31,6 +31,8 @@
  * @copyright CiviCRM LLC (c) 2004-2018
  */
 class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
+  protected $defaultAssigneeOptionsIds = array();
+
   /**
    * Run.
    *
@@ -582,41 +584,42 @@ AND        a.is_deleted = 0
       return NULL;
     }
 
-    $defaultAssigneeOptionsIds = $this->getDefaultAssigneeOptionIds();
+    $this->setupDefaultAssigneeOptionIds();
 
     switch($activityTypeXML->default_assignee_type) {
-      case $defaultAssigneeOptionsIds['BY_RELATIONSHIP']:
+      case $this->defaultAssigneeOptionsIds['BY_RELATIONSHIP']:
         return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML);
         break;
-      case $defaultAssigneeOptionsIds['SPECIFIC_CONTACT']:
+      case $this->defaultAssigneeOptionsIds['SPECIFIC_CONTACT']:
         return $this->getDefaultAssigneeBySpecificContact($activityTypeXML);
         break;
-      case $defaultAssigneeOptionsIds['USER_CREATING_THE_CASE']:
+      case $this->defaultAssigneeOptionsIds['USER_CREATING_THE_CASE']:
         return $activityParams['source_contact_id'];
         break;
-      case $defaultAssigneeOptionsIds['NONE']:
+      case $this->defaultAssigneeOptionsIds['NONE']:
       default:
         return null;
     }
   }
 
   /**
-   * Returns a list of default assignee options indexed by their name.
+   * Fetches and caches the activity's default assignee options.
    *
    * @return array
    */
-  protected function getDefaultAssigneeOptionIds() {
+  protected function setupDefaultAssigneeOptionIds() {
+    if (!empty($this->defaultAssigneeOptionsIds)) {
+      return $defaultAssigneeOptionsIds;
+    }
+
     $defaultAssigneeOptions =  civicrm_api3('OptionValue', 'get', array(
       'option_group_id' => 'activity_default_assignee',
       'options' => array('limit' => 0)
     ));
-    $defaultAssigneeOptionsIds = array();
 
     foreach($defaultAssigneeOptions['values'] as $option) {
-      $defaultAssigneeOptionsIds[$option['name']] = $option['id'];
+      $this->defaultAssigneeOptionsIds[$option['name']] = $option['id'];
     }
-
-    return $defaultAssigneeOptionsIds;
   }
 
   /**

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -584,6 +584,9 @@ AND        a.is_deleted = 0
       case $defaultAssigneeOptionsIds['BY_RELATIONSHIP']:
         return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML);
         break;
+      case $defaultAssigneeOptionsIds['SPECIFIC_CONTACT']:
+        return $this->getDefaultAssigneeBySpecificContact($activityTypeXML);
+        break;
       default:
         return null;
     }
@@ -629,6 +632,26 @@ AND        a.is_deleted = 0
 
     if ($relationships['count']) {
       return $relationships['values'][0]['contact_id_a'];
+    } else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Returns the activity's default assignee for a specific contact if the contact exists,
+   * otherwise returns null.
+   *
+   * @param object $activityTypeXML
+   * @return int|null
+   */
+  protected function getDefaultAssigneeBySpecificContact($activityTypeXML) {
+    $contact = new CRM_Contact_BAO_Contact();
+    $contact->id = $activityTypeXML->default_assignee_contact;
+
+    if (!$contact->id) {
+      return NULL;
+    } else if ($contact->find(TRUE)) {
+      return $contact->id;
     } else {
       return NULL;
     }

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -549,7 +549,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    * This is sympathetic to sites who might pre-add it.
    *
    * @param array $params the option value attributes.
-   * @return object the option value.
+   * @return array the option value attributes.
    */
   public static function ensureOptionValueExists($params) {
     $result = civicrm_api3('OptionValue', 'get', array(

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -549,23 +549,21 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    * This is sympathetic to sites who might pre-add it.
    *
    * @param array $params the option value attributes.
-   * @return the option value id.
+   * @return object the option value.
    */
   public static function ensureOptionValueExists($params) {
-    $existingValues = civicrm_api3('OptionValue', 'get', array(
+    $result = civicrm_api3('OptionValue', 'get', array(
       'option_group_id' => $params['option_group_id'],
       'name' => $params['name'],
-      'return' => 'id',
+      'return' => ['id', 'value'],
       'sequential' => 1
     ));
 
-    if (!$existingValues['count']) {
+    if (!$result['count']) {
       $result = civicrm_api3('OptionValue', 'create', $params);
-
-      return $result['id'];
-    } else {
-      return $existingValues['values'][0]['id'];
     }
+
+    return CRM_Utils_Array::first($result['values']);
   }
 
 }

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -547,15 +547,24 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    * that an option value exists, without hitting an error if it already exists.
    *
    * This is sympathetic to sites who might pre-add it.
+   *
+   * @param array $params the option value attributes.
+   * @return the option value id.
    */
   public static function ensureOptionValueExists($params) {
     $existingValues = civicrm_api3('OptionValue', 'get', array(
       'option_group_id' => $params['option_group_id'],
       'name' => $params['name'],
       'return' => 'id',
+      'sequential' => 1
     ));
+
     if (!$existingValues['count']) {
-      civicrm_api3('OptionValue', 'create', $params);
+      $result = civicrm_api3('OptionValue', 'create', $params);
+
+      return $result['id'];
+    } else {
+      return $existingValues['values'][0]['id'];
     }
   }
 

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -76,7 +76,7 @@ Required vars: activitySet
           ui-jq="select2"
           ui-options="{ dropdownAutoWidth: true }"
           ng-model="activity.default_assignee_relationship"
-          ng-options="option as option.text for option in relationshipTypeOptions"
+          ng-options="option.id as option.text for option in relationshipTypeOptions"
           required
         ></select>
       </p>

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -67,11 +67,11 @@ Required vars: activitySet
         ui-jq="select2"
         ui-options="{ dropdownAutoWidth: true }"
         ng-model="activity.default_assignee_type"
-        ng-options="option.id as option.label for option in defaultAssigneeTypes"
+        ng-options="option.value as option.label for option in defaultAssigneeTypes"
         ng-change="clearActivityDefaultAssigneeValues(activity)"
       ></select>
 
-      <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.BY_RELATIONSHIP.id">
+      <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.BY_RELATIONSHIP.value">
         <select
           ui-jq="select2"
           ui-options="{ dropdownAutoWidth: true }"
@@ -81,7 +81,7 @@ Required vars: activitySet
         ></select>
       </p>
 
-      <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.SPECIFIC_CONTACT.id">
+      <p ng-if="activity.default_assignee_type === defaultAssigneeTypesIndex.SPECIFIC_CONTACT.value">
         <input
           type="text"
           ng-model="activity.default_assignee_contact"

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -24,7 +24,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
       'activity_date_time' => date('Ymd'),
       'caseID' => $this->caseTypeId,
       'clientID' => $this->targetContactId,
-      'creatorID' => $this->assigneeContactId,
+      'creatorID' => $this->_loggedInUser,
     );
 
     $this->process = new CRM_Case_XMLProcessor_Process();
@@ -117,6 +117,17 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
     $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
+   * Tests the creation of activities with the default assignee being the one
+   * creating the case's activity.
+   */
+  public function testCreateActivityAssignedToUserCreatingTheCase() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['USER_CREATING_THE_CASE'];
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists($this->_loggedInUser);
   }
 
   /**

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -39,18 +39,18 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
       'NONE', 'BY_RELATIONSHIP', 'SPECIFIC_CONTACT', 'USER_CREATING_THE_CASE'
     );
 
-    $this->callAPISuccess('OptionGroup', 'create', array(
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(array(
       'name' => 'activity_default_assignee'
     ));
 
     foreach ($options as $option) {
-      $result = $this->callAPISuccess('OptionValue', 'create', array(
+      $optionValueId = CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
         'option_group_id' => 'activity_default_assignee',
         'name' => $option,
         'label' => $option
       ));
 
-      $this->defaultAssigneeOptionsIds[$option] = $result['id'];
+      $this->defaultAssigneeOptionsIds[$option] = $optionValueId;
     }
   }
 

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -1,0 +1,98 @@
+<?php
+require_once 'CiviTest/CiviCaseTestCase.php';
+
+/**
+ * Class CRM_Case_PseudoConstantTest
+ * @group headless
+ */
+class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
+
+  public function setUp() {
+    parent::setUp();
+
+    $this->defaultAssigneeOptionsIds = array();
+    $this->assigneeContactId = $this->individualCreate();
+    $this->targetContactId = $this->individualCreate();
+
+    $this->setUpDefaultAssigneeOptions();
+    $this->setUpRelationship();
+
+    $this->activityTypeXml = (object) array(
+      'name' => 'Open Case'
+    );
+    $this->params = array(
+      'activity_date_time' => date('Ymd'),
+      'caseID' => $this->caseTypeId,
+      'clientID' => $this->targetContactId,
+      'creatorID' => $this->assigneeContactId,
+    );
+
+    $this->process = new CRM_Case_XMLProcessor_Process();
+  }
+
+  /**
+   * Adds the default assignee group and options to the test database.
+   * It also stores the IDs of the options in an index.
+   */
+  protected function setUpDefaultAssigneeOptions() {
+    $options = array(
+      'NONE', 'BY_RELATIONSHIP', 'SPECIFIC_CONTACT', 'USER_CREATING_THE_CASE'
+    );
+
+    $this->callAPISuccess('OptionGroup', 'create', array(
+      'name' => 'activity_default_assignee'
+    ));
+
+    foreach ($options as $option) {
+      $result = $this->callAPISuccess('OptionValue', 'create', array(
+        'option_group_id' => 'activity_default_assignee',
+        'name' => $option,
+        'label' => $option
+      ));
+
+      $this->defaultAssigneeOptionsIds[$option] = $result['id'];
+    }
+  }
+
+  /**
+   * Adds a relationship between the activity's target contact and default assignee.
+   */
+  protected function setUpRelationship() {
+    $this->relationshipTypeId = $this->relationshipTypeCreate(array(
+      'contact_type_a' => 'Individual',
+      'contact_type_b' => 'Individual'
+    ));
+    $this->relationshipId = $this->callAPISuccess('Relationship', 'create', array(
+      'contact_id_a' => $this->assigneeContactId,
+      'contact_id_b' => $this->targetContactId,
+      'relationship_type_id' => $this->relationshipTypeId
+    ));
+  }
+
+  /**
+   * Tests the creation of activities with default assignee by relationship.
+   */
+  public function testCreateActivityWithDefaultContactByRelationship() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['BY_RELATIONSHIP'];
+    $this->activityTypeXml->default_assignee_relationship = $this->relationshipTypeId;
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists();
+  }
+
+  /**
+   * Asserts that a an activity was created where the assignee was the one related
+   * to the target contact.
+   * It also deletes this activity from the test database.
+   */
+  protected function assertActivityAssignedToContactExists() {
+    $activity = $this->callAPISuccess('Activity', 'getsingle', array(
+      'assignee_contact_id' => $this->assigneeContactId
+    ));
+
+    $this->assertNotNull($activity, 'Contact has no activities assigned to them');
+
+    CRM_Activity_BAO_Activity::deleteActivityContact($activity['id'], 1);
+  }
+
+}

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -131,6 +131,24 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
   }
 
   /**
+   * Tests the creation of activities when the default assignee is set to NONE.
+   */
+  public function testCreateActivityAssignedNoUser() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['NONE'];
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
+   * Tests the creation of activities when the default assignee is set to NONE.
+   */
+  public function testCreateActivityWithNoDefaultAssigneeOption() {
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
    * Asserts that a an activity was created where the assignee was the one related
    * to the target contact.
    * It also deletes this activity from the test database.

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -10,7 +10,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
   public function setUp() {
     parent::setUp();
 
-    $this->defaultAssigneeOptionsIds = [];
+    $this->defaultAssigneeOptionsValues = [];
     $this->assigneeContactId = $this->individualCreate();
     $this->targetContactId = $this->individualCreate();
 
@@ -42,13 +42,13 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
     ]);
 
     foreach ($options as $option) {
-      $optionValueId = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      $optionValue = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
         'option_group_id' => 'activity_default_assignee',
         'name' => $option,
         'label' => $option
       ]);
 
-      $this->defaultAssigneeOptionsIds[$option] = $optionValueId;
+      $this->defaultAssigneeOptionsValues[$option] = $optionValue['value'];
     }
   }
 
@@ -75,7 +75,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * Tests the creation of activities with default assignee by relationship.
    */
   public function testCreateActivityWithDefaultContactByRelationship() {
-    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['BY_RELATIONSHIP'];
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['BY_RELATIONSHIP'];
     $this->activityTypeXml->default_assignee_relationship = $this->relationshipTypeId;
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
@@ -87,7 +87,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * but the target contact doesn't have any relationship of the selected type.
    */
   public function testCreateActivityWithDefaultContactByRelationButTheresNoRelationship() {
-    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['BY_RELATIONSHIP'];
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['BY_RELATIONSHIP'];
     $this->activityTypeXml->default_assignee_relationship = $this->unassignedRelationshipTypeId;
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
@@ -98,7 +98,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * Tests the creation of activities with default assignee set to a specific contact.
    */
   public function testCreateActivityAssignedToSpecificContact() {
-    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['SPECIFIC_CONTACT'];
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['SPECIFIC_CONTACT'];
     $this->activityTypeXml->default_assignee_contact = $this->assigneeContactId;
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
@@ -110,7 +110,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * but the contact does not exist.
    */
   public function testCreateActivityAssignedToNonExistantSpecificContact() {
-    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['SPECIFIC_CONTACT'];
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['SPECIFIC_CONTACT'];
     $this->activityTypeXml->default_assignee_contact = 987456321;
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
@@ -122,7 +122,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * creating the case's activity.
    */
   public function testCreateActivityAssignedToUserCreatingTheCase() {
-    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['USER_CREATING_THE_CASE'];
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['USER_CREATING_THE_CASE'];
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
     $this->assertActivityAssignedToContactExists($this->_loggedInUser);
@@ -132,7 +132,7 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * Tests the creation of activities when the default assignee is set to NONE.
    */
   public function testCreateActivityAssignedNoUser() {
-    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['NONE'];
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsValues['NONE'];
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
     $this->assertActivityAssignedToContactExists(NULL);

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -84,9 +84,36 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
     $this->assertActivityAssignedToContactExists($this->assigneeContactId);
   }
 
+  /**
+   * Tests the creation of activities with default assignee by relationship,
+   * but the target contact doesn't have any relationship of the selected type.
+   */
   public function testCreateActivityWithDefaultContactByRelationButTheresNoRelationship() {
     $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['BY_RELATIONSHIP'];
     $this->activityTypeXml->default_assignee_relationship = $this->unassignedRelationshipTypeId;
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists(NULL);
+  }
+
+  /**
+   * Tests the creation of activities with default assignee set to a specific contact.
+   */
+  public function testCreateActivityAssignedToSpecificContact() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['SPECIFIC_CONTACT'];
+    $this->activityTypeXml->default_assignee_contact = $this->assigneeContactId;
+
+    $this->process->createActivity($this->activityTypeXml, $this->params);
+    $this->assertActivityAssignedToContactExists($this->assigneeContactId);
+  }
+
+  /**
+   * Tests the creation of activities with default assignee set to a specific contact,
+   * but the contact does not exist.
+   */
+  public function testCreateActivityAssignedToNonExistantSpecificContact() {
+    $this->activityTypeXml->default_assignee_type = $this->defaultAssigneeOptionsIds['SPECIFIC_CONTACT'];
+    $this->activityTypeXml->default_assignee_contact = 987456321;
 
     $this->process->createActivity($this->activityTypeXml, $this->params);
     $this->assertActivityAssignedToContactExists(NULL);

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -10,22 +10,20 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
   public function setUp() {
     parent::setUp();
 
-    $this->defaultAssigneeOptionsIds = array();
+    $this->defaultAssigneeOptionsIds = [];
     $this->assigneeContactId = $this->individualCreate();
     $this->targetContactId = $this->individualCreate();
 
     $this->setUpDefaultAssigneeOptions();
     $this->setUpRelationship();
 
-    $this->activityTypeXml = (object) array(
-      'name' => 'Open Case'
-    );
-    $this->params = array(
+    $this->activityTypeXml = (object) [ 'name' => 'Open Case' ];
+    $this->params = [
       'activity_date_time' => date('Ymd'),
       'caseID' => $this->caseTypeId,
       'clientID' => $this->targetContactId,
       'creatorID' => $this->_loggedInUser,
-    );
+    ];
 
     $this->process = new CRM_Case_XMLProcessor_Process();
   }
@@ -35,20 +33,20 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * It also stores the IDs of the options in an index.
    */
   protected function setUpDefaultAssigneeOptions() {
-    $options = array(
+    $options = [
       'NONE', 'BY_RELATIONSHIP', 'SPECIFIC_CONTACT', 'USER_CREATING_THE_CASE'
-    );
+    ];
 
-    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists(array(
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
       'name' => 'activity_default_assignee'
-    ));
+    ]);
 
     foreach ($options as $option) {
-      $optionValueId = CRM_Core_BAO_OptionValue::ensureOptionValueExists(array(
+      $optionValueId = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
         'option_group_id' => 'activity_default_assignee',
         'name' => $option,
         'label' => $option
-      ));
+      ]);
 
       $this->defaultAssigneeOptionsIds[$option] = $optionValueId;
     }
@@ -58,19 +56,19 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
    * Adds a relationship between the activity's target contact and default assignee.
    */
   protected function setUpRelationship() {
-    $this->relationshipTypeId = $this->relationshipTypeCreate(array(
+    $this->relationshipTypeId = $this->relationshipTypeCreate([
       'contact_type_a' => 'Individual',
       'contact_type_b' => 'Individual'
-    ));
-    $this->unassignedRelationshipTypeId = $this->relationshipTypeCreate(array(
+    ]);
+    $this->unassignedRelationshipTypeId = $this->relationshipTypeCreate([
       'name_a_b' => 'Instructor of',
       'name_b_a' => 'Pupil of'
-    ));
-    $this->relationshipId = $this->callAPISuccess('Relationship', 'create', array(
+    ]);
+    $this->relationshipId = $this->callAPISuccess('Relationship', 'create', [
       'contact_id_a' => $this->assigneeContactId,
       'contact_id_b' => $this->targetContactId,
       'relationship_type_id' => $this->relationshipTypeId
-    ));
+    ]);
   }
 
   /**
@@ -149,21 +147,18 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
   }
 
   /**
-   * Asserts that a an activity was created where the assignee was the one related
+   * Asserts that an activity was created where the assignee was the one related
    * to the target contact.
-   * It also deletes this activity from the test database.
    *
    * @param int|null the ID of the expected assigned contact or NULL if expected to be empty.
    */
   protected function assertActivityAssignedToContactExists($assigneeContactId) {
-    $activity = $this->callAPISuccess('Activity', 'getsingle', array(
+    $activity = $this->callAPISuccess('Activity', 'getsingle', [
       'target_contact_id' => $this->targetContactId,
       'assignee_contact_id' => $assigneeContactId
-    ));
+    ]);
 
     $this->assertNotNull($activity, 'Contact has no activities assigned to them');
-
-    CRM_Activity_BAO_Activity::deleteActivityContact($activity['id'], 1);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/OptionValueTest.php
+++ b/tests/phpunit/CRM/Core/BAO/OptionValueTest.php
@@ -72,12 +72,15 @@ class CRM_Core_BAO_OptionValueTest extends CiviUnitTestCase {
    * decision to disable it & leaving it in that state.
    */
   public function testEnsureOptionValueExistsDisabled() {
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status', 'is_active' => 0));
+    $optionValueId = CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status', 'is_active' => 0));
     $value = $this->callAPISuccessGetSingle('OptionValue', array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
     $this->assertEquals(0, $value['is_active']);
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
+    $this->assertEquals($value['id'], $optionValueId);
+
+    $optionValueId = CRM_Core_BAO_OptionValue::ensureOptionValueExists(array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
     $value = $this->callAPISuccessGetSingle('OptionValue', array('name' => 'Crashed', 'option_group_id' => 'contribution_status'));
     $this->assertEquals(0, $value['is_active']);
+    $this->assertEquals($value['id'], $optionValueId);
   }
 
 }


### PR DESCRIPTION
## Description

This PR assigns an activity's assignee using the "default assignee" values defined for the activity.

To see how the default assignee options are stored please refer to https://github.com/compucorp/civicrm-core/pull/12

## Activity's default assignee values
![housing support hr17 9100](https://user-images.githubusercontent.com/1642119/37811433-97af663c-2e30-11e8-96f4-10abd9c25044.png)
The target contact for this demo will be Barry Adams, his parent is Russell Adams.

## Before
![dr barry adams ii housing support hr17 9100 1](https://user-images.githubusercontent.com/1642119/37811552-64a2ce36-2e31-11e8-94c3-342af4a52e92.png)

## After
![dr barry adams ii housing support hr17 9100](https://user-images.githubusercontent.com/1642119/37811505-0e4d1bd6-2e31-11e8-98c1-ab07f2a9abb3.png)

## Technical Details

The default assignee is selected when creating the activity at the `CRM_Case_XMLProcessor_Process::createActivity` function since this one has most of the information we need to select the assignee:

```php
public function createActivity($activityTypeXML, &$params) {
  // ...
  $activityParams['assignee_contact_id'] = $this->getDefaultAssigneeForActivity($activityParams, $activityTypeXML);
  // ...
}
```

The `getDefaultAssigneeForActivity` function determines the assignee for the activity based on the activity type definition and the stored default assignee type:

```php
protected function getDefaultAssigneeForActivity($activityParams, $activityTypeXML) {
  if (!isset($activityTypeXML->default_assignee_type)) {
    return NULL;
  }

  // fetches the default assignee types to see which strategy to choose for the default assignee
  $this->setupDefaultAssigneeOptionIds();

  switch($activityTypeXML->default_assignee_type) {
    case $this->defaultAssigneeOptionsIds['BY_RELATIONSHIP']:
      return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML);
      break;
    case $this->defaultAssigneeOptionsIds['SPECIFIC_CONTACT']:
      return $this->getDefaultAssigneeBySpecificContact($activityTypeXML);
      break;
    case $this->defaultAssigneeOptionsIds['USER_CREATING_THE_CASE']:
      return $activityParams['source_contact_id'];
      break;
    case $this->defaultAssigneeOptionsIds['NONE']:
    default:
      return null;
  }
}
```

`getDefaultAssigneeByRelationship` is the strategy for selecting an assignee by the relationship to the target contact:

```php
protected function getDefaultAssigneeByRelationship($activityParams, $activityTypeXML) {
  if (!isset($activityTypeXML->default_assignee_relationship)) {
    return NULL;
  }

  // the target contact might come wrapped as an array sometimes, this extract the id from the array:
  $targetContactId = is_array($activityParams['target_contact_id'])
    ? $activityParams['target_contact_id'][0]
    : $activityParams['target_contact_id'];

  // finds the relation to the target contact:
  $relationships = civicrm_api3('Relationship', 'get', array(
    'contact_id_b' => $targetContactId,
    'relationship_type_id.name' => $activityTypeXML->default_assignee_relationship,
    'sequential' => 1
  ));

  if ($relationships['count']) {
    // returns the other relation contact:
    return $relationships['values'][0]['contact_id_a'];
  } else {
    return NULL;
  }
}
```

`getDefaultAssigneeBySpecificContact` is the strategy when choosing a specific contact. It returns the ID only if the contact exists in case the contact were to be deleted at a later time:

```php
protected function getDefaultAssigneeBySpecificContact($activityTypeXML) {
  $contact = new CRM_Contact_BAO_Contact();
  $contact->id = $activityTypeXML->default_assignee_contact;

  if (!$contact->id) {
    return NULL;
  } else if ($contact->find(TRUE)) {
    return $contact->id;
  } else {
    return NULL;
  }
}
```

### Tests

The `CRM_Case_XMLProcessor_Process` class was missing a test file so a new was created at:
`tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php`, but only tests related to the default assignee selections were added.

`CRM_Core_BAO_OptionValue::ensureOptionValueExists` had to be enhanced to return the option value id whether it finds the value or creates a new one.


