### PR TITLE
PCHR-3304: Fix bug with "is_locked" functionality

### DIFF
--- a/CRM/Admin/Page/Options.php
+++ b/CRM/Admin/Page/Options.php
@@ -81,6 +81,7 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
   public function preProcess() {
     if (!self::$_gName && !empty($this->urlPath[3])) {
       self::$_gName = $this->urlPath[3];
+      self::$_isLocked = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', self::$_gName, 'is_locked', 'name');
     }
     // If an id arg is passed instead of a group name in the path
     elseif (!self::$_gName && !empty($_GET['gid'])) {

--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -143,6 +143,18 @@ class CRM_Core_BAO_CustomOption {
         $class .= ' disabled';
         $action -= CRM_Core_Action::DISABLE;
       }
+
+      $isGroupLocked = (bool) CRM_Core_DAO::getFieldValue(
+        CRM_Core_DAO_OptionGroup::class,
+        $field->option_group_id,
+        'is_locked'
+      );
+
+      // disable deletion of option values for locked option groups
+      if ($isGroupLocked) {
+        $action -= CRM_Core_Action::DELETE;
+      }
+
       if (in_array($field->html_type, array('CheckBox', 'AdvMulti-Select', 'Multi-Select'))) {
         if (isset($defVal) && in_array($dao->value, $defVal)) {
           $options[$dao->id]['is_default'] = '<img src="' . $config->resourceBase . 'i/check.gif" />';

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -72,14 +72,14 @@ class CRM_Core_OptionValue {
    */
   public static function getRows($groupParams, $links, $orderBy = 'weight', $skipEmptyComponents = TRUE) {
     $optionValue = array();
-
     $optionGroupID = NULL;
+    $isGroupLocked = FALSE;
+
     if (!isset($groupParams['id']) || !$groupParams['id']) {
       if ($groupParams['name']) {
-        $config = CRM_Core_Config::singleton();
-
         $optionGroup = CRM_Core_BAO_OptionGroup::retrieve($groupParams, $dnc);
         $optionGroupID = $optionGroup->id;
+        $isGroupLocked = (bool) $optionGroup->is_locked;
       }
     }
     else {
@@ -144,6 +144,11 @@ class CRM_Core_OptionValue {
         ) {
           $action -= CRM_Core_Action::DELETE;
         }
+      }
+
+      // disallow deletion of option values for locked groups
+      if ($isGroupLocked) {
+        $action -= CRM_Core_Action::DELETE;
       }
 
       $optionValue[$dao->id]['label'] = htmlspecialchars($optionValue[$dao->id]['label']);

--- a/CRM/Custom/Page/Option.php
+++ b/CRM/Custom/Page/Option.php
@@ -90,18 +90,18 @@ class CRM_Custom_Page_Option extends CRM_Core_Page {
         CRM_Core_Action::DISABLE => array(
           'name' => ts('Disable'),
           'ref' => 'crm-enable-disable',
-          'title' => ts('Disable Mutliple Choice Option'),
+          'title' => ts('Disable Multiple Choice Option'),
         ),
         CRM_Core_Action::ENABLE => array(
           'name' => ts('Enable'),
           'ref' => 'crm-enable-disable',
-          'title' => ts('Enable Mutliple Choice Option'),
+          'title' => ts('Enable Multiple Choice Option'),
         ),
         CRM_Core_Action::DELETE => array(
           'name' => ts('Delete'),
           'url' => 'civicrm/admin/custom/group/field/option',
           'qs' => 'action=delete&id=%%id%%&fid=%%fid%%',
-          'title' => ts('Disable Multiple Choice Option'),
+          'title' => ts('Delete Multiple Choice Option'),
         ),
       );
     }
@@ -189,8 +189,13 @@ WHERE  option_group_id = %1";
     );
 
     if ($isReserved = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_gid, 'is_reserved', 'id')) {
-      CRM_Core_Error::fatal("You cannot add or edit muliple choice options in a reserved custom field-set.");
+      CRM_Core_Error::fatal("You cannot add or edit multiple choice options in a reserved custom field-set.");
     }
+
+    $optionGroupId = $this->getOptionGroupId($this->_fid);
+    $isOptionGroupLocked = $optionGroupId ? $this->isOptionGroupLocked($optionGroupId) : FALSE;
+    $this->assign('optionGroupId', $optionGroupId);
+    $this->assign('isOptionGroupLocked', $isOptionGroupLocked);
 
     //as url contain $gid so append breadcrumb dynamically.
     $breadcrumb = array(
@@ -237,6 +242,36 @@ WHERE  option_group_id = %1";
     }
     // Call the parents run method
     return parent::run();
+  }
+
+  /**
+   * Gets the "is_locked" status for the provided option group
+   *
+   * @param int $optionGroupId
+   *
+   * @return bool
+   */
+  private function isOptionGroupLocked($optionGroupId) {
+    return (bool) CRM_Core_DAO::getFieldValue(
+      CRM_Core_DAO_OptionGroup::class,
+      $optionGroupId,
+      'is_locked'
+    );
+  }
+
+  /**
+   * Gets the associated "option_group_id" for a custom field
+   *
+   * @param int $customFieldId
+   *
+   * @return int
+   */
+  private function getOptionGroupId($customFieldId) {
+    return (int) CRM_Core_DAO::getFieldValue(
+      CRM_Core_DAO_CustomField::class,
+      $customFieldId,
+      'option_group_id'
+    );
   }
 
 }

--- a/templates/CRM/Custom/Page/Option.tpl
+++ b/templates/CRM/Custom/Page/Option.tpl
@@ -157,7 +157,9 @@
       {/literal}
 
       <div class="action-link">
-          {crmButton q="reset=1&action=add&fid=$fid&gid=$gid" class="action-item" icon="plus-circle"}{ts}Add Option{/ts}{/crmButton}
+          {if !$isOptionGroupLocked}
+            {crmButton q="reset=1&action=add&fid=$fid&gid=$gid" class="action-item" icon="plus-circle"}{ts}Add Option{/ts}{/crmButton}
+          {/if}
           {crmButton p="civicrm/admin/custom/group/field" q="reset=1&action=browse&gid=$gid" class="action-item cancel" icon="times"}{ts}Done{/ts}{/crmButton}
       </div>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------

Locked option groups don't always hide the option to delete or add option values. This PR fixes that. See more information in the [core PR](https://github.com/civicrm/civicrm-core/pull/11962)