### PR TITLE
PCHR-4346: Fix custom Home URL parsing

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -48,7 +48,7 @@ class CRM_Admin_Page_AJAX {
       $smarty = CRM_Core_Smarty::singleton();
       $smarty->assign('includeEmail', civicrm_api3('setting', 'getvalue', array('name' => 'includeEmailInName', 'group' => 'Search Preferences')));
       print $smarty->fetchWith('CRM/common/navigation.js.tpl', array(
-        'navigation' => CRM_Core_BAO_Navigation::createNavigation($contactID),
+        'navigation' => CRM_Core_BAO_Navigation::createNavigation(),
       ));
     }
     CRM_Utils_System::civiExit();


### PR DESCRIPTION
Overview
----------------------------------------

The `CRM/Core/BAO/Navigation.php` has been overridden in CiviHR to fix an E_NOTICE thrown while parsing the custom URL we use for the Home page (see https://github.com/compucorp/civihr/pull/924).

In the past, besides this error fix, there were other customizations added to this file, but after some time they have been removed and this was the last one remaining, as it can be seenn in this diff: https://www.diffchecker.com/kQra6Xsf.

Since this is an error in core, I've [submitted a PR](https://github.com/civicrm/civicrm-core/pull/13031) to fix it there so that we can remove the overridden file.

Before
----------------------------------------

The `Navigation.php` file was overridden in CiviHR to fix an error in CiviCRM core.

After
----------------------------------------

The error has been fixed in Core and the overridden file isn't necessary anymore.

Comments
----------------------------------------

This PR is targeting the `5.7.0-beta1-patches` branch because the work to upgrade CiviHR to the latest CiviCRM version is still in progress and 5.7.0 has not been released yet (according to the CiviCRM release scheduled, it should be out on the first Wednesday of November). After the new version is out, a new `5.7.0-patches` branch will be created and it will include this patch.

For reference, this is the PR which removes the file from CiviHR: https://github.com/compucorp/civihr/pull/2899