### PR TITLE
PCHR-4346: Fix menu width issues

### DIFF
--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -11,5 +11,7 @@ CRM.$(function($) {
         $('#toolbar').css('z-index', '');
       }
     });
-    $('#civicrm-menu').css({'width': '97%'});
+  if ($('#toolbar a.toggle').length) {
+    $('#civicrm-menu').css({width: 'calc(100% - 40px)'});
+  }
 });


### PR DESCRIPTION
Overview
----------------------------------------

On CiviCRM 5.6.0, the code used to add the navigation menu to the pages has been refactored, and this affected how the menu width is calculated causing problems to the user dropdown menu in CiviHR. See this more details: https://github.com/civicrm/civicrm-core/pull/12463#issuecomment-433929931

This has been fixed already, but the fix will only be included in CiviCRM 5.8.0: https://github.com/civicrm/civicrm-core/pull/12937, so this is simply a backport of that to 5.7.0

Before
-------------------------------------------

The user dropdown looks displaced after upgrading the CiviCRM 5.7.0:

![2018-10-29-111920_1419x122_scrot](https://user-images.githubusercontent.com/388373/47656204-68bdfd80-db6d-11e8-997d-beab856fb4e2.png)

After
--------------------------------------------

The user dropdown is correctly placed in CiviCRM 5.7.0:

![2018-10-29-111928_1391x59_scrot](https://user-images.githubusercontent.com/388373/47656191-62c81c80-db6d-11e8-8a5e-78d4e3e997da.png)

Comments
----------------------------------------

This PR is targeting the `5.7.0-beta1-patches` branch because the work to upgrade CiviHR to the latest CiviCRM version is still in progress and 5.7.0 has not been released yet (according to the CiviCRM release scheduled, it should be out on the first Wednesday of November). After the new version is out, a new `5.7.0-patches` branch will be created and it will include this patch.