### PR TITLE
C51-396: Rearranging Quicksearch Options

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -100,7 +100,29 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     // store the submitted values in an array
     $params = $this->controller->exportValues($this->_name);
 
+    self::enforceSorting($params);
     self::commonProcess($params);
+  }
+
+  /**
+   * @todo Enforces the sorting done on the front end.
+   * 
+   * @param array $params
+   */
+  public function enforceSorting(&$params) {
+    if (strlen($params['sorted_quicksearch_options']) > 0) {
+      $qsOptions = $params['quicksearch_options'];
+      $sortedQSOptionsKeys = explode(',', $params['sorted_quicksearch_options']);
+      $sortedQSOptions = [];
+      foreach($sortedQSOptionsKeys as $sortedQSOptionsKey) {
+        if (isset($qsOptions[$sortedQSOptionsKey])) {
+          $sortedQSOptions[$sortedQSOptionsKey] = $qsOptions[$sortedQSOptionsKey];
+        }
+      }
+
+      $params['quicksearch_options'] = $sortedQSOptions;
+      unset($params['sorted_quicksearch_options']);
+    }
   }
 
   /**

--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -50,6 +50,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     'smartGroupCacheTimeout' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'defaultSearchProfileID' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'searchPrimaryDetailsOnly' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'default_quicksearch_option' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'quicksearch_options' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   );
 

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -234,6 +234,10 @@ trait CRM_Admin_Form_SettingTrait {
         else {
           $this->$add($setting, ts($props['title']), $options);
         }
+
+        $sortable = CRM_Utils_Array::value('sortable', $props, FALSE);
+        $this->assign("{$setting}_sortable", $sortable);
+
         // Migrate to using an array as easier in smart...
         $description = CRM_Utils_Array::value('description', $props);
         $descriptions[$setting] = $description;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -603,6 +603,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $this->addElement('hidden', 'entryURL', $this->controller->_entryURL);
     }
 
+    // Hidden field to hold re-sorted quicksearch options
+    $this->addElement('hidden', 'sorted_quicksearch_options', '', [
+      'id' => 'sortedQuicksearchOptions',
+    ]);
+
     $this->buildQuickForm();
 
     $defaults = $this->setDefaultValues();

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3887,3 +3887,11 @@ ul.crm-sortable *:hover {
 ul.crm-sortable input {
   cursor: default !important;
 }
+
+ul.crm-sortable li::before {
+  font-family: "FontAwesome";
+  content: "\f0b2";
+  margin: 0 5px;
+  padding-right: 3px;
+  vertical-align: middle;
+}

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3878,20 +3878,22 @@ ul.crm-search-setting-form-block-quicksearch_options-list {
   list-style: none;
   margin: 0 !important;
   padding-left: 0 !important;
+  /* width: 60%; */
+  display: inline-block;
+}
+
+ul.crm-search-setting-form-block-quicksearch_options-list li {
+  margin: 0 2px 2px 2px;
+  padding: 0.4em;
+  height: 14px;
+  vertical-align: middle;
 }
 
 ul.crm-sortable *:hover {
   cursor: move;
 }
 
-ul.crm-sortable input {
+ul.crm-sortable li input,
+ul.crm-sortable li tt {
   cursor: default !important;
-}
-
-ul.crm-sortable li::before {
-  font-family: "FontAwesome";
-  content: "\f0b2";
-  margin: 0 5px;
-  padding-right: 3px;
-  vertical-align: middle;
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3873,3 +3873,17 @@ span.crm-status-icon {
   border-radius: 3px;
   border: 1px solid grey;
 }
+
+ul.crm-search-setting-form-block-quicksearch_options-list {
+  list-style: none;
+  margin: 0 !important;
+  padding-left: 0 !important;
+}
+
+ul.crm-sortable *:hover {
+  cursor: move;
+}
+
+ul.crm-sortable input {
+  cursor: default !important;
+}

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -251,4 +251,25 @@ return array(
     'description' => ts("Which fields can be searched on in the menubar quicksearch box? Don't see your custom field here? Make sure it is marked as Searchable."),
     'help_text' => NULL,
   ),
+  'default_quicksearch_option' => array(
+    'group_name' => 'Search Preferences',
+    'group' => 'Search Preferences',
+    'name' => 'default_quicksearch_option',
+    'type' => 'string',
+    'quick_form_type' => 'Select',
+    'html_type' => 'Select',
+    'html_attributes' => array(
+      'class' => 'crm-select2',
+    ),
+    'pseudoconstant' => array(
+      'callback' => 'CRM_Core_SelectValues::quicksearchOptions',
+    ),
+    'default' => NULL,
+    'add' => '5.8',
+    'title' => ts('Default quicksearch option'),
+    'is_domain' => '1',
+    'is_contact' => 0,
+    'description' => ts("If set, this will be the default search field in the menubar quicksearch boxWhich fields can be searched on in the menubar quicksearch box."),
+    'help_text' => NULL,
+  ),
 );

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -81,11 +81,15 @@
                 <ul class="crm-search-setting-form-block-quicksearch_options-list{if $quicksearch_options_sortable} crm-sortable{/if}">
                 {foreach from=$form.quicksearch_options item=quicksearch_option}
                     {if is_array($quicksearch_option) && array_key_exists('html', $quicksearch_option)}
-                    <li>{$quicksearch_option.html}</li>
+                    <li class="ui-state-default">
+                        <span class="ui-icon ui-icon-arrowthick-2-n-s"></span>
+                        {$quicksearch_option.html}
+                    </li>
                     {/if}
                 {/foreach}
                 </ul>
                 <p class="description">{$setting_descriptions.quicksearch_options}</p>
+                {$form.sorted_quicksearch_options.html}
             </td>
         </tr>
         <tr class="crm-search-setting-form-block-autocompleteContactSearch">
@@ -119,7 +123,16 @@
 {literal}
 <script type="text/javascript">
 CRM.$(function($) {
-    $('.crm-sortable').sortable();
+    $('.crm-sortable').sortable({
+        update: function( event, ui ) {
+            var qsCheckboxes = $(event.target).find('input'),
+                sortedOptions = [];
+            for (var i = 0; i < qsCheckboxes.length; i++) {
+                sortedOptions.push(qsCheckboxes[i].name.split(/[\[\]]/)[1]);
+            }
+            $('#sortedQuicksearchOptions').val(sortedOptions);
+        }
+    });
     $('.crm-sortable').disableSelection();
 });
 </script>

--- a/templates/CRM/Admin/Form/Setting/Search.tpl
+++ b/templates/CRM/Admin/Form/Setting/Search.tpl
@@ -68,10 +68,23 @@
             <td>{$form.smartGroupCacheTimeout.html}<br />
                 <span class="description">{ts}The number of minutes to cache smart group contacts. We strongly recommend that this value be greater than zero, since a value of zero means no caching at all. If your contact data changes frequently, you should set this value to at least 5 minutes.{/ts}</span></td>
         </tr>
+        <tr class="crm-search-setting-form-block-default_quicksearch_option">
+            <td class="label">{$form.default_quicksearch_option.label}</td>
+            <td>
+                {$form.default_quicksearch_option.html}
+                <p class="description">{$setting_descriptions.default_quicksearch_option}</p>
+            </td>
+        </tr>
         <tr class="crm-search-setting-form-block-quicksearch_options">
             <td class="label">{$form.quicksearch_options.label}</td>
             <td>
-                {$form.quicksearch_options.html}
+                <ul class="crm-search-setting-form-block-quicksearch_options-list{if $quicksearch_options_sortable} crm-sortable{/if}">
+                {foreach from=$form.quicksearch_options item=quicksearch_option}
+                    {if is_array($quicksearch_option) && array_key_exists('html', $quicksearch_option)}
+                    <li>{$quicksearch_option.html}</li>
+                    {/if}
+                {/foreach}
+                </ul>
                 <p class="description">{$setting_descriptions.quicksearch_options}</p>
             </td>
         </tr>
@@ -102,3 +115,12 @@
             <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 
 </div>
+
+{literal}
+<script type="text/javascript">
+CRM.$(function($) {
+    $('.crm-sortable').sortable();
+    $('.crm-sortable').disableSelection();
+});
+</script>
+{/literal}


### PR DESCRIPTION
Overview
----------------------------------------
_Read more at this [Gitlab ticket](https://lab.civicrm.org/dev/core/issues/628)._

_The PR aims to add the ability to rearrange the quick search options so that the External ID field is at the top of the search options and add a new setting for setting a default quicksearch option._

Before
----------------------------------------
_Action was not present._
![C51-396](https://raw.githubusercontent.com/16kilobyte/screenshots/master/C51-396-before-1.png)

After
----------------------------------------
_Action has been implemented_
![C51-396](https://raw.githubusercontent.com/16kilobyte/screenshots/master/C51-396-after-1.png)

