### PR TITLE
PI-48: Add workflow to generate patched tarballs

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,0 +1,57 @@
+name: Packaging
+on: push
+
+env:
+  base_version: 5.19.4
+
+jobs:
+  build:
+    name: Packaging
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Civi
+        env:
+          civi_package: civicrm-${{ env.base_version }}-drupal.tar.gz
+        run: |
+          cd ..
+          pwd
+          mkdir to-be-patched
+          wget https://storage.googleapis.com/civicrm/civicrm-stable/${base_version}/${civi_package}
+          tar xzf ./${civi_package} -C to-be-patched
+
+      - name: Checkout the fork
+        uses: actions/checkout@v2-beta
+        with:
+          ref: ${{ env.base_version }}
+
+      - name: Create patched package
+        uses: 'compucorp/create-patch-from-fork@1.0.0'
+        id: "patch"
+        with:
+          base_version: ${{ env.base_version }}
+          project_dir: '../to-be-patched/civicrm'
+          project_name: 'civicrm'
+          project_type: 'civicrm-core'
+
+      - name: Create a new release
+        id: create_release
+        uses: compucorp/create-release@target_commitish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "${{ steps.patch.outputs.version }}"
+          target_commitish: "${{ github.sha }}"
+          release_name: "${{ steps.patch.outputs.version }}"
+          body: "${{ steps.patch.outputs.version }}"
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "${{ steps.patch.outputs.package_path }}"
+          asset_name: "${{ steps.patch.outputs.package }}"
+          asset_content_type: application/gzip


### PR DESCRIPTION
CiviCRM Core cannot be installed on sites by simply cloned the civicrm-core repository. We actually need to download the tarball from their site and extract the files in our project. This is due to the fact that CiviCRM is actually a combination of files in multiple different repositories and some additional thirdy party dependencies (like php libraries installed with composer and frontend libs with bower and npm).

For this reason, if we ever want the patches in this fork to be applied to a project, it's not possible to simply clone the fork. We actually need the same files as the ones in the tarball but with our patch applied.

This PR introduces an Actions workflow that solves this problem by doing the following:

- Downloads the original package from the CiviCRM site
- Extracts the file
- Creates a patch file from the patches branch
- Applies this patch to the download files
- Creates a new package with the patched files
- Tag and create a new release on the fork
- Add the patched package as an asset to the release

This way, if someone ever needs to install a patched version of CiviCRM core, all that is necessary is to download the patched tarball from the Github Release.

The tags follow the following pattern `<BASE VERSION>+patch.<PATCH VERSION>`
where:

- BASE VERSION is the original version we want to patch (for example, 5.19.4)
- PATCH VERSION is the short HASH of the Git commit in the patches branch from which the patch was generated

A limitation of this approach is that, due to the number not being sequential, it might not be easy to see what is the latest patch for a certain version. Making it sequential would make the workflow code more complex, so, for now, this was not implemented. Hopefully we won't need too many patches, which means we won't have too many tags and it will be easy to spot the latest one simply by checking the release date on the releases page on Github.

The workflow will run automatically, whenever a new commit is pushed/merged to
the patches branch.

This workflow depends on a custom action for the patching part. This action is on a separate repo: http://github.com/compucorp/create-patch-from-fork 