### PR TITLE
CATL-1446: Contact Card's email addresses link

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1268,6 +1268,18 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
             }
             $params[$index] = $details->$detailName;
           }
+          elseif ($fieldName == 'email') {
+            $detailId = $detailName . '_id';
+            $emailId = $details->$detailId;
+            $emailPopupUrl = CRM_Utils_System::url('civicrm/activity/email/add', [
+              'action' => 'add',
+              'reset' => '1',
+              'cid' => $cid,
+              'email_id' => $emailId,
+            ], TRUE);
+            $values[$index] = '<a class="crm-popup" href="' . $emailPopupUrl . '">' .
+              $details->$detailName . '</a>';
+          }
           else {
             $values[$index] = $params[$index] = $details->$detailName;
           }

--- a/js/Common.js
+++ b/js/Common.js
@@ -1027,6 +1027,8 @@ if (!CRM.vars) CRM.vars = {};
   };
 
   $.fn.crmtooltip = function () {
+    var TOOLTIP_HIDE_DELAY = 300;
+
     $(document)
       .on('mouseover', 'a.crm-summary-link:not(.crm-processed)', function (e) {
         $(this).addClass('crm-processed crm-tooltip-active');
@@ -1041,8 +1043,13 @@ if (!CRM.vars) CRM.vars = {};
             .load(this.href);
         }
       })
-      .on('mouseout', 'a.crm-summary-link', function () {
-        $(this).removeClass('crm-processed crm-tooltip-active crm-tooltip-down');
+      .on('mouseleave', 'a.crm-summary-link', function () {
+        var tooltipLink = $(this);
+        setTimeout(function () {
+          if (tooltipLink.filter(':hover').length === 0) {
+            tooltipLink.removeClass('crm-processed crm-tooltip-active crm-tooltip-down');
+          }
+        }, TOOLTIP_HIDE_DELAY);
       })
       .on('click', 'a.crm-summary-link', false);
   };


### PR DESCRIPTION
## Overview

This PR applies the changes introduced by dev/core#1790 to our CiviCRM version.

The changes are related to allowing users to click on email addresses on Contact's cards and send emails to these addresses using the email activity form. For more information please visit the original PR:

https://github.com/civicrm/civicrm-core/pull/17517