### PR TITLE
SPAB-975: Fix Calculation of Overridden Membership Status

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1434,9 +1434,14 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
         $relMembership = new CRM_Member_DAO_Membership();
         $relMembership->contact_id = $contactId;
         $relMembership->owner_membership_id = $membership->id;
+
         if ($relMembership->find(TRUE)) {
           $params['id'] = $relMembership->id;
         }
+        else {
+          unset($params['id']);
+        }
+
         $params['contact_id'] = $contactId;
         $params['owner_membership_id'] = $membership->id;
 


### PR DESCRIPTION
Overview
----------------------------------------
Under certain special circumstances, once a main membership that has related memberships (eg. a membership held by an employer for a maximum number of employees), if the status is overridden for a specific date, and the date has been met so that status for the main membership and its related memberships can now be calculated by the membership status calculation job, some of the related memberships may get deleted.

The specific conditions that need to be met are:

- Have an organization with a membership that has a maximum number of related memberships via a specific relationship (eg. 3 maximum related contacts with employee relationship).
- Have more contacts related to the organization that the maximum related memberships (eg 5)
- Distribute the memberships to the contacts so that the first created contact, and the last contacts have the related memberships.
- Give the main membership an overridden status for a date in the past.

The fix has been sent to CiviCRM core. It was reported here:
https://lab.civicrm.org/dev/core/-/issues/1854

And fixed in this PR:
https://github.com/civicrm/civicrm-core/pull/17742

Before
----------------------------------------
When a membership has an overridden status until a certain date, and that date is met, the status calculation job will remove the restriction by setting the relevant fields to null, and updating the membership. If that membership has related memberships, the change will be replicated to each membership. To cycle through the memberships, the system will go through the list of all related contacts, and check if each contact has a membership. If the parent membership has a limit on maximum related memberships, the system will start counting memberships, and delete any memberships found after reaching the limit.

The problem presents itself when a membership is found for the n-th contact related to the organization, and the (n+1)-th contact doesn't have a membership, and the (n+b)-th contact does have a membership, where b > 1. When cycling trough the contacts, the ID of the related membership is stored on `$params['id']`. When the system reaches the (n+1)-th contact, which does not have a membership, the instruction to store the membership id is skipped. This means `$params['id']` will now hold the ID of the membership for the n-th contact, which will get updated, and counted twice. Thus, the number of allowed memberships will be reached before all memberships are actually accounted for. Thus, memberships after the max limit is reached will be deleted. 

Furthermore, if there is a contact without a membership after a deleted membership, the same membership will deleted twice, causing a fatal error to be thrown here:

https://github.com/civicrm/civicrm-core/blob/b7bfc6be2f3e6c62548f85571ef032d2989c80cf/CRM/Member/BAO/Membership.php#L641

After
----------------------------------------
Changed the cycle through related contacts, such that if a membersihp fir it does not exeist, `$params['id']` is unset. This will cause the memberships to be counted truthfully, and no side effect of deleting valid memberships will be triggered, nor the double deletion of a membership.
