### PR TITLE
ASESPRT-238: Fix error that prevents from recording refund

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5365,33 +5365,41 @@ LIMIT 1;";
       return [];
     }
     $actionLinks = [];
+    $actionLinks[] = [
+      'url' => CRM_Utils_System::url('civicrm/payment', [
+        'action' => 'add',
+        'reset' => 1,
+        'id' => $id,
+        'is_refund' => 0,
+      ]),
+      'title' => ts('Record Payment'),
+    ];
+
     if ((int) $balance > 0) {
+      // @todo - this should be possible even if not > 0 - test & remove this if.
+      // it is possible to 'overpay' in the real world & we honor that.
       if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
         $actionLinks[] = [
           'url' => CRM_Utils_System::url('civicrm/payment', [
             'action' => 'add',
             'reset' => 1,
+            'is_refund' => 0,
             'id' => $id,
             'mode' => 'live',
           ]),
           'title' => ts('Submit Credit Card payment'),
         ];
       }
-      $actionLinks[] = [
-        'url' => CRM_Utils_System::url('civicrm/payment', [
-          'action' => 'add',
-          'reset' => 1,
-          'id' => $id,
-        ]),
-        'title' => ts('Record Payment'),
-      ];
     }
     elseif ((int) $balance < 0) {
+      // @todo - in the future remove this IF - OK to refund money even when not due since
+      // ... life.
       $actionLinks[] = [
         'url' => CRM_Utils_System::url('civicrm/payment', [
           'action' => 'add',
           'reset' => 1,
           'id' => $id,
+          'is_refund' => 1,
         ]),
         'title' => ts('Record Refund'),
       ];

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -48,7 +48,7 @@
     <tr class="crm-payment-form-block-total_amount">
       <td class="label">{$form.total_amount.label}</td>
       <td>
-        <span id='totalAmount'>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.total_amount.html|crmAddClass:eight}</span>&nbsp; <span class="status">{if $paymentType EQ 'refund'}{ts}Refund Due{/ts}{else}{ts}Balance Owed{/ts}{/if}:&nbsp;{$paymentAmt|crmMoney}</span>
+        <span id='totalAmount'>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.total_amount.html|crmAddClass:eight}</span>&nbsp; <span class="status">{if $paymentType EQ 'refund' || $paymentAmt < 0}{ts}Refund Due :&nbsp;{$absolutePaymentAmount|crmMoney} {/ts}{else}{ts}Balance Owed{/ts} :&nbsp;{$paymentAmt|crmMoney}{/if}</span>
       </td>
       {if $email and $outBound_option != 2}
         <tr class="crm-payment-form-block-is_email_receipt">


### PR DESCRIPTION
Overview
----------------------------------------
Included in CiviCRM 5.26.2 (already merged, we are just backporting the fix to our branch)
PR link: https://github.com/civicrm/civicrm-core/pull/16480

We had an issue where **Record Refund** was throwing error as shown in the screenshot below:
![image](https://user-images.githubusercontent.com/7393885/86141861-2aca6700-bb10-11ea-9f1d-9bfbc502b3af.png)

This is a core issue and is sorted in latest CiviCRM version 5.26.2. Hence we are patching our 5.24.6-patches branch with the PR that sorted it out: https://github.com/civicrm/civicrm-core/pull/16480.

Before
----------------------------------------
**Record refund** was not possible when the amount is like 10.99, 1.23 etc. It worked fine for amounts like 11, 12, 1 etc.

After
----------------------------------------
**Record refund** works fine for all amounts.

Technical Details
----------------------------------------
This was happening because there was a comparison happening in code (**CRM/Contribute/Form/AdditionalPayment.php**) where the values were like

`$fields['total_amount'] = 11.99`
`abs($self->_refund) = 11.9800000009`

because of the above format, even when it showed both values correct on the UI, in the backend the values were not equal and hence the issue was shown.
