### PR TITLE
IESSPRT-148: Fix authorization issue when saving message templates

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -399,13 +399,15 @@ abstract class AbstractAction implements \ArrayAccess {
       'default' => ['administer CiviCRM'],
     ];
     $action = $this->getActionName();
-    if (isset($permissions[$action])) {
-      return $permissions[$action];
-    }
-    elseif (in_array($action, ['getActions', 'getFields'])) {
-      return $permissions['meta'];
-    }
-    return $permissions['default'];
+    // Map specific action names to more generic versions
+    $map = [
+      'getActions' => 'meta',
+      'getFields' => 'meta',
+      'replace' => 'delete',
+      'save' => 'create',
+    ];
+    $generic = $map[$action] ?? 'default';
+    return $permissions[$action] ?? $permissions[$generic] ?? $permissions['default'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Users with `CiviCRM: edit message templates` are not able to save templates because of the core issue https://lab.civicrm.org/dev/core/-/issues/2008 which got fixed in this PR: https://github.com/civicrm/civicrm-core/pull/18437
This patch is part of civicrm 5.30.0 but we want it in 5.28.3 because it is compuclient supported.
Adding above mentioned patch as part of this PR.

Before
----------------------------------------
Users with `CiviCRM: edit message templates` permission were getting access denied:
![Screenshot_2020-12-02 https ies-master-pcg compubox co uk](https://user-images.githubusercontent.com/7393885/100878459-3ca1a300-34d0-11eb-81a0-f9eb41a44399.png)


After
----------------------------------------
Users with `CiviCRM: edit message templates` permission are able to save message templates.
