### PR TITLE
COMCL-99: Apply patches do not get merged into civicrm-core from 5.28.3-patches

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -613,6 +613,10 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function save($hook = TRUE) {
     $eventID = uniqid();
+    if ($hook) {
+      CRM_Utils_Hook::preSave($this);
+    }
+
     if (!empty($this->id)) {
       if ($hook) {
         $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -478,11 +478,29 @@ DESC limit 1");
           $selOrgMemType[$memberOfContactId][$key] = $values['name'] ?? NULL;
         }
       }
+
       $totalAmount = $values['minimum_fee'] ?? NULL;
-      //CRM-18827 - override the default value if total_amount is submitted
-      if (!empty($this->_submitValues['total_amount'])) {
+
+      // CRM-18827 - override the default value if total_amount is submitted
+      // dev/core#778 - This should only happen for the selected membership type!
+      $isSelectedMembershipType = $values['id'] === $this->_submitValues['membership_type_id'][1];
+      if ($isSelectedMembershipType && !empty($this->_submitValues['total_amount'])) {
         $totalAmount = CRM_Utils_Rule::cleanMoney($this->_submitValues['total_amount']);
+
+        $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+        $financial_type_id = CRM_Utils_Array::value('financial_type_id', $values);
+        $membershipTypeTaxRate = CRM_Utils_Array::value($financial_type_id, $taxRates);
+
+        /**
+         * dev/core#778: If value was submitted, tax rates will have been added,
+         * so we need to subtract them, otw they will get recalculated and added
+         * again by front-end!
+         */
+        if (!empty($membershipTypeTaxRate)) {
+          $totalAmount = $totalAmount / (1 + $membershipTypeTaxRate / 100);
+        }
       }
+
       // build membership info array, which is used when membership type is selected to:
       // - set the payment information block
       // - set the max related block

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1580,6 +1580,19 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
+  public static function preSave(&$dao) {
+    $hookName = 'civicrm_preSave_' . $dao->getTableName();
+    return self::singleton()->invoke(array('dao'), $dao,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $hookName
+    );
+  }
+
+  /**
+   * @param CRM_Core_DAO $dao
+   *
+   * @return mixed
+   */
   public static function postSave(&$dao) {
     $hookName = 'civicrm_postSave_' . $dao->getTableName();
     return self::singleton()->invoke(['dao'], $dao,


### PR DESCRIPTION
### Overview

The purpose of this PR is to apply patches that do not get merged into CiviCRM Core to Compucorp's CiviCRM fork for CiviCRM 5.35 RC. 

The patches were cherry-picked from existing commits in version 5.28.3-patches  then fixed conflicts with version 5.35 RC

The previous commits are

- https://github.com/compucorp/civicrm-core/commit/07cd5b4a2e8824c099e2cec297f8da26ffa44b6f
- https://github.com/compucorp/civicrm-core/commit/88ae7cc3fc471bd15be6fa614642944d708a245c

### Noted 

There were other three patches that were applied into 5.28.3 patches (See [commits](https://github.com/compucorp/civicrm-core/commits/5.28.3-patches)) and have already been merged into the civicrm-core. 

The commits are: 

- https://github.com/compucorp/civicrm-core/commit/8d34819c216bfe7085b731a6cc5c78d83604e421
- https://github.com/compucorp/civicrm-core/commit/cfd7491fa9c5d9fee22abf470f50ab4b6b34fd46
- https://github.com/compucorp/civicrm-core/commit/f44359ff3558de4408306127ea68284f9f1afdc3
