### PR TITLE
CPS-484: Fix Drupal Base 'isFrontEndPage' Returns Wrong Value After Saving A Settings Page

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -117,6 +117,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     Civi::cache('session')->clear();
     CRM_Utils_System::flushCache();
     CRM_Core_Resources::singleton()->resetCacheCode();
+    $this->rebuildMenu();
 
     CRM_Core_Session::setStatus(" ", ts('Changes Saved'), "success");
   }

--- a/CRM/Admin/Form/Setting/Path.php
+++ b/CRM/Admin/Form/Setting/Path.php
@@ -58,8 +58,6 @@ class CRM_Admin_Form_Setting_Path extends CRM_Admin_Form_Setting {
 
   public function postProcess() {
     parent::postProcess();
-
-    parent::rebuildMenu();
   }
 
 }

--- a/CRM/Admin/Form/Setting/Url.php
+++ b/CRM/Admin/Form/Setting/Url.php
@@ -81,8 +81,6 @@ class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
     $session->getStatus(TRUE);
 
     parent::postProcess();
-
-    parent::rebuildMenu();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
When a settings page such as Civicase settings (civicrm/admin/setting/case), Mailing settings (civicrm/admin/mail) and most of the setting pages are saved the styles of the page redirected to gets broken and shoreditch theme is not applied. 
More details in the core PR: https://github.com/civicrm/civicrm-core/pull/19823