### PR TITLE
CIVIPLUS-180: Simplify afform event naming

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -10,6 +10,9 @@ use Civi\Afform\Event\AfformSubmitEvent;
  */
 class Submit extends AbstractProcessor {
 
+  /**
+   * @deprecated - You may simply use the event name directly. dev/core#1744
+   */
   const EVENT_NAME = 'civi.afform.submit';
 
   /**
@@ -34,7 +37,7 @@ class Submit extends AbstractProcessor {
     }
 
     $event = new AfformSubmitEvent($this->_formDataModel->getEntities(), $entityValues);
-    \Civi::dispatcher()->dispatch(self::EVENT_NAME, $event);
+    \Civi::dispatcher()->dispatch('civi.afform.submit', $event);
     foreach ($event->entityValues as $entityType => $entities) {
       if (!empty($entities)) {
         throw new \API_Exception(sprintf("Failed to process entities (type=%s; name=%s)", $entityType, implode(',', array_keys($entities))));

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -2,7 +2,6 @@
 
 require_once 'afform.civix.php';
 use CRM_Afform_ExtensionUtil as E;
-use Civi\Api4\Action\Afform\Submit;
 
 /**
  * Filter the content of $params to only have supported afform fields.
@@ -49,8 +48,8 @@ function afform_civicrm_config(&$config) {
   }
   Civi::$statics[__FUNCTION__] = 1;
 
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processContacts'], 500);
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);
+  Civi::dispatcher()->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processContacts'], 500);
+  Civi::dispatcher()->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processGenericEntity'], -1000);
   Civi::dispatcher()->addListener('hook_civicrm_angularModules', ['\Civi\Afform\AngularDependencyMapper', 'autoReq'], -1000);
   Civi::dispatcher()->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the missing class error that stopped the deployment for sites with `afform` extensions enabled.

Before
----------------------------------------
The deployment process will fail with the following error:
```php
Error: Class "Civi\Api4\Action\Afform\Submit" not found in afform_civicrm_config() (line 52 of civicrm/ext/afform/core/afform.php).
Drush command terminated abnormally due to an unrecoverable error
```

After
----------------------------------------
The deployment process will finish successfully.

Technical Details
----------------------------------------
The deployment process complained about the missing class `Civi\Api4\Action\Afform\Submit`. I investigated the issue and confirmed the file was loaded: 
```bash
# Added 'var_dump(Submit::class);die()' before afform.php:52
$ drush rr                                                                                     
The registry has been rebuilt via registry_rebuild (A).                                                                                                       [success]
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? advuser.module:552                                                    [warning]
string(30) "Civi\Api4\Action\Afform\Submit"
Drush command terminated abnormally due to an unrecoverable error.
```

To overcome this issue, I used the sting literal instead of the constant for the event name.
```diff
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processContacts'], 500);                                                                         
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);                                                                  
+  Civi::dispatcher()->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processContacts'], 500);                                                   
+  Civi::dispatcher()->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processGenericEntity'], -1000);  
```

Since CiviCRM 5.26, the convention was to use string literal for event names and the usage of constants was deprecated according to this issue [#1744](https://lab.civicrm.org/dev/core/-/issues/1744). This was the last usage of constants for event names in CiviCRM code base.



Comments
----------------------------------------
I couldn't replicate this issue in any of my local sites.