### PR TITLE
CIVIPLUS-150: Set ssl option when using DSN with SSL

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -327,7 +327,8 @@ class CRM_Utils_File {
       require_once 'DB.php';
       $dsn = CRM_Utils_SQL::autoSwitchDSN($dsn);
       try {
-        $db = DB::connect($dsn);
+        $options = CRM_Utils_SQL::isSSLDSN($dsn) ? ['ssl' => TRUE] : [];
+        $db = DB::connect($dsn, $options);
       }
       catch (Exception $e) {
         die("Cannot open $dsn: " . $e->getMessage());


### PR DESCRIPTION
Overview
----------------------------------------

This PR applies a patch PR: https://github.com/civicrm/civicrm-core/pull/20974 so CiviCRM 5.35.2 patches support SSL on the installation. 

