### PR TITLE
CATL-2216: Ability to change pdf filename before downloading

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -178,8 +178,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
+    $fileName = self::getFileName($form);
+    $fileName = "$fileName.$type";
+
     if ($type == 'pdf') {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
@@ -187,7 +189,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip);
     }
     else {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Document::html2doc($html, $fileName, $formValues);
     }
 
@@ -213,6 +214,29 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $form->postProcessHook();
 
     CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Returns the filename for the pdf by striping off unwanted characters and limits the length to 200 characters.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @return string
+   *   The name of the file.
+   */
+  private static function getFileName(CRM_Core_Form $form) {
+    if (!empty($form->getSubmittedValue('pdf_file_name'))) {
+      $fileName = CRM_Utils_String::munge($form->getSubmittedValue('pdf_file_name'), '_', 200);
+    }
+    elseif (!empty($form->getSubmittedValue('subject'))) {
+      $fileName = CRM_Utils_String::munge($form->getSubmittedValue('subject'), '_', 200);
+    }
+    else {
+      $fileName = 'CiviLetter';
+    }
+    $fileName = self::isLiveMode($form) ? $fileName : $fileName . '_preview';
+
+    return $fileName;
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -179,6 +179,19 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   public $submitOnce = FALSE;
 
   /**
+   * Values submitted by the user.
+   *
+   * These values have been checked for injection per
+   * https://pear.php.net/manual/en/package.html.html-quickform.html-quickform.exportvalues.php
+   * and are as submitted.
+   *
+   * Once set this array should be treated as read only.
+   *
+   * @var array
+   */
+  protected $exportedValues = [];
+
+  /**
    * @return string
    */
   public function getContext() {
@@ -2717,6 +2730,23 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
     $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this);
     return CRM_Contact_BAO_Contact_Utils::validChecksum($contactID, $userChecksum) ? $contactID : FALSE;
+  }
+
+  /**
+   * Get values submitted by the user.
+   *
+   * These values have been validated against the fields added to the form.
+   * https://pear.php.net/manual/en/package.html.html-quickform.html-quickform.exportvalues.php
+   *
+   * @param string $fieldName
+   *
+   * @return mixed|null
+   */
+  protected function getSubmittedValue(string $fieldName) {
+    if (empty($this->exportedValues)) {
+      $this->exportedValues = $this->controller->exportValues($this->_name);
+    }
+    return $this->exportedValues[$fieldName] ?? NULL;
   }
 
 }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2742,7 +2742,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return mixed|null
    */
-  protected function getSubmittedValue(string $fieldName) {
+  public function getSubmittedValue(string $fieldName) {
     if (empty($this->exportedValues)) {
       $this->exportedValues = $this->controller->exportValues($this->_name);
     }

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -52,6 +52,10 @@ class CRM_Core_Form_Task_PDFLetterCommon {
       FALSE
     );
 
+    // Added for core#2121,
+    // To support sending a custom pdf filename before downloading.
+    $form->addElement('hidden', 'pdf_file_name', []);
+
     $form->addSelect('format_id', [
       'label' => ts('Select Format'),
       'placeholder' => ts('Default'),

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -478,6 +478,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @param array $formValues
    */
   public function testSubmit(array $formValues): void {
+    $this->exportedValues = $formValues;
     $this->setContextVariables($formValues);
     $this->_memType = $formValues['membership_type_id'][1];
     $this->_params = $formValues;

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC. All rights reserved.                        |
+|                                                                    |
+| This work is published under the GNU AGPLv3 license with some      |
+| permitted exceptions and without any warranty. For full license    |
+| and copyright information, see https://civicrm.org/licensing       |
++--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for CRM_Contact_Form_Task_PDFLetterCommon.
+ *
+ * @group headless
+ */
+class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
+
+  /**
+   * Contact ID.
+   *
+   * @var int
+   */
+  protected $contactId;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->contactId = $this->createLoggedInUser();
+  }
+
+  /**
+   * Test the pdf filename is assigned as expected.
+   *
+   * @param string|null $pdfFileName
+   *   Value for pdf_file_name param.
+   * @param string|null $activitySubject
+   *   Value of the subject of the activity.
+   * @param bool|null $isLiveMode
+   *   TRUE when the form is in live mode, NULL when it is a preview.
+   * @param string $expectedFilename
+   *   Expected filename assigned to the pdf.
+   *
+   * @dataProvider getFilenameCases
+   */
+  public function testFilenameIsAssigned(?string $pdfFileName, ?string $activitySubject, ?bool $isLiveMode, string $expectedFilename): void {
+    $_REQUEST['cid'] = $this->contactId;
+    $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', [
+      'pdf_file_name' => $pdfFileName,
+      'subject' => $activitySubject,
+      '_contactIds' => [],
+      'document_type' => 'pdf',
+      'buttons' => [
+        '_qf_PDF_upload' => $isLiveMode,
+      ],
+    ]);
+    $fileNameAssigned = NULL;
+    $form->preProcess();
+    try {
+      $form->postProcess();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $fileNameAssigned = $e->errorData['fileName'];
+    }
+
+    $this->assertEquals($expectedFilename, $fileNameAssigned);
+  }
+
+  /**
+   * DataProvider for testFilenameIsAssigned.
+   *
+   * @return array
+   *   Array with the test information.
+   */
+  public function getFilenameCases(): array {
+    return [
+      [
+        'FilenameInParam',
+        'FilenameInActivitySubject',
+        NULL,
+        'FilenameInParam_preview',
+      ],
+      [
+        'FilenameInParam',
+        'FilenameInActivitySubject',
+        TRUE,
+        'FilenameInParam',
+      ],
+      [
+        NULL,
+        'FilenameInActivitySubject',
+        NULL,
+        'FilenameInActivitySubject_preview',
+      ],
+      [
+        NULL,
+        'FilenameInActivitySubject',
+        TRUE,
+        'FilenameInActivitySubject',
+      ],
+      [
+        NULL,
+        NULL,
+        NULL,
+        'CiviLetter_preview',
+      ],
+      [
+        NULL,
+        NULL,
+        TRUE,
+        'CiviLetter',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Core PR: https://github.com/civicrm/civicrm-core/pull/21006

Also the code from https://github.com/civicrm/civicrm-core/commit/6aef13891489db249061daa4c2c225d7c0aa0737, has been added in order to use `getSubmittedValue` function.
Note: Only the code needed for `getSubmittedValue` function is added, not the whole commit.