### PR TITLE
PROD-13: Apply patches for 5.39.1

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,0 +1,60 @@
+name: Packaging
+on:
+  push:
+   branches: 
+    - 5.39.1-patches
+
+env:
+  base_version: 5.39.1
+
+jobs:
+  build:
+    name: Packaging
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Civi
+        env:
+          civi_package: civicrm-${{ env.base_version }}-drupal.tar.gz
+        run: |
+          cd ..
+          pwd
+          mkdir to-be-patched
+          wget https://storage.googleapis.com/civicrm/civicrm-stable/${base_version}/${civi_package}
+          tar xzf ./${civi_package} -C to-be-patched
+
+      - name: Checkout the fork
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.base_version }}
+
+      - name: Create patched package
+        uses: 'compucorp/create-patch-from-fork@1.0.0'
+        id: "patch"
+        with:
+          base_version: ${{ env.base_version }}
+          project_dir: '../to-be-patched/civicrm'
+          project_name: 'civicrm'
+          project_type: 'civicrm-core'
+
+      - name: Create a new release
+        id: create_release
+        uses: compucorp/create-release@target_commitish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "${{ steps.patch.outputs.version }}"
+          target_commitish: "${{ github.sha }}"
+          release_name: "${{ steps.patch.outputs.version }}"
+          body: "${{ steps.patch.outputs.version }}"
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "${{ steps.patch.outputs.package_path }}"
+          asset_name: "${{ steps.patch.outputs.package }}"
+          asset_content_type: application/gzip

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -178,8 +178,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
+    $fileName = self::getFileName($form);
+    $fileName = "$fileName.$type";
+
     if ($type == 'pdf') {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
@@ -187,7 +189,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip);
     }
     else {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Document::html2doc($html, $fileName, $formValues);
     }
 
@@ -213,6 +214,29 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $form->postProcessHook();
 
     CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Returns the filename for the pdf by striping off unwanted characters and limits the length to 200 characters.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @return string
+   *   The name of the file.
+   */
+  private static function getFileName(CRM_Core_Form $form) {
+    if (!empty($form->getSubmittedValue('pdf_file_name'))) {
+      $fileName = CRM_Utils_String::munge($form->getSubmittedValue('pdf_file_name'), '_', 200);
+    }
+    elseif (!empty($form->getSubmittedValue('subject'))) {
+      $fileName = CRM_Utils_String::munge($form->getSubmittedValue('subject'), '_', 200);
+    }
+    else {
+      $fileName = 'CiviLetter';
+    }
+    $fileName = self::isLiveMode($form) ? $fileName : $fileName . '_preview';
+
+    return $fileName;
   }
 
   /**

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4699,11 +4699,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'membership_activity_status' => 'Completed',
       ];
 
-      $currentMembership = CRM_Member_BAO_Membership::getContactMembership($membershipParams['contact_id'],
-        $membershipParams['membership_type_id'],
-        $membershipParams['is_test'],
-        $membershipParams['id']
-      );
+      $currentMembership = [];
+      CRM_Member_BAO_Membership::retrieve($membershipParams, $currentMembership);
 
       // CRM-8141 update the membership type with the value recorded in log when membership created/renewed
       // this picks up membership type changes during renewals
@@ -4721,7 +4718,8 @@ LIMIT 1;";
           $membershipParams['membership_type_id'] = $dao->membership_type_id;
         }
       }
-      if (empty($membership['end_date']) || (int) $membership['status_id'] !== CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending')) {
+      $pendingMembershipStatusID = CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending');
+      if (empty($membership['end_date']) || (int) $membership['status_id'] !== $pendingMembershipStatusID) {
         // Passing num_terms to the api triggers date calculations, but for pending memberships these may be already calculated.
         // sigh - they should  be  consistent but removing the end date check causes test failures & maybe UI too?
         // The api assumes num_terms is a special sauce for 'is_renewal' so we need to not pass it when updating a pending to completed.
@@ -4739,7 +4737,16 @@ LIMIT 1;";
         'start_date',
         'end_date',
       ], NULL);
-      if ($currentMembership) {
+      if ($currentMembership && (int) $currentMembership['status_id'] === $pendingMembershipStatusID) {
+        $currentMembership['join_date'] = $currentMembership['join_date'] ?? NULL;
+        $currentMembership['start_date'] = $currentMembership['start_date'] ?? NULL;
+        $currentMembership['end_date'] = $currentMembership['end_date'] ?? NULL;
+
+        $dates = CRM_Member_BAO_MembershipType::getDatesForMembershipType($membershipParams['membership_type_id'],
+          $currentMembership['join_date'], $currentMembership['start_date'], $currentMembership['end_date']
+        );
+      }
+      else {
         /*
          * Fixed FOR CRM-4433
          * In BAO/Membership.php(renewMembership function), we skip the extend membership date and status

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -616,6 +616,10 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function save($hook = TRUE) {
     $eventID = uniqid();
+    if ($hook) {
+      CRM_Utils_Hook::preSave($this);
+    }
+
     if (!empty($this->id)) {
       if ($hook) {
         $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2742,7 +2742,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return mixed|null
    */
-  protected function getSubmittedValue(string $fieldName) {
+  public function getSubmittedValue(string $fieldName) {
     if (empty($this->exportedValues)) {
       $this->exportedValues = $this->controller->exportValues($this->_name);
     }

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -53,6 +53,10 @@ class CRM_Core_Form_Task_PDFLetterCommon {
       FALSE
     );
 
+    // Added for core#2121,
+    // To support sending a custom pdf filename before downloading.
+    $form->addElement('hidden', 'pdf_file_name', []);
+
     $form->addSelect('format_id', [
       'label' => ts('Select Format'),
       'placeholder' => ts('Default'),

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -327,7 +327,8 @@ class CRM_Utils_File {
       require_once 'DB.php';
       $dsn = CRM_Utils_SQL::autoSwitchDSN($dsn);
       try {
-        $db = DB::connect($dsn);
+        $options = CRM_Utils_SQL::isSSLDSN($dsn) ? ['ssl' => TRUE] : [];
+        $db = DB::connect($dsn, $options);
       }
       catch (Exception $e) {
         die("Cannot open $dsn: " . $e->getMessage());

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1580,6 +1580,19 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
+  public static function preSave(&$dao) {
+    $hookName = 'civicrm_preSave_' . $dao->getTableName();
+    return self::singleton()->invoke(array('dao'), $dao,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $hookName
+    );
+  }
+
+  /**
+   * @param CRM_Core_DAO $dao
+   *
+   * @return mixed
+   */
   public static function postSave(&$dao) {
     $hookName = 'civicrm_postSave_' . $dao->getTableName();
     return self::singleton()->invoke(['dao'], $dao,

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -182,6 +182,8 @@ class CRM_Utils_PDF_Utils {
     // CRM-12165 - Remote file support required for image handling.
     $options = new Options();
     $options->set('isRemoteEnabled', TRUE);
+    $cmsRootPath = \CRM_Core_Config::singleton()->userSystem->cmsRootPath() . '/';
+    $options->set('chroot', $cmsRootPath);
 
     $dompdf = new DOMPDF($options);
     $dompdf->set_paper($paper_size, $orientation);

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -500,7 +500,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, 
   if (isset($profileFields[$profileID])) {
     return $profileFields[$profileID];
   }
-  $fields = civicrm_api3('uf_field', 'get', ['uf_group_id' => $profileID]);
+  $fields = civicrm_api3('uf_field', 'get', ['uf_group_id' => $profileID, 'options' => ['limit' => 0]]);
   $entities = [];
   foreach ($fields['values'] as $field) {
     if (!$field['is_active']) {

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC. All rights reserved.                        |
+|                                                                    |
+| This work is published under the GNU AGPLv3 license with some      |
+| permitted exceptions and without any warranty. For full license    |
+| and copyright information, see https://civicrm.org/licensing       |
++--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for CRM_Contact_Form_Task_PDFLetterCommon.
+ *
+ * @group headless
+ */
+class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
+
+  /**
+   * Contact ID.
+   *
+   * @var int
+   */
+  protected $contactId;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->contactId = $this->createLoggedInUser();
+  }
+
+  /**
+   * Test the pdf filename is assigned as expected.
+   *
+   * @param string|null $pdfFileName
+   *   Value for pdf_file_name param.
+   * @param string|null $activitySubject
+   *   Value of the subject of the activity.
+   * @param bool|null $isLiveMode
+   *   TRUE when the form is in live mode, NULL when it is a preview.
+   * @param string $expectedFilename
+   *   Expected filename assigned to the pdf.
+   *
+   * @dataProvider getFilenameCases
+   */
+  public function testFilenameIsAssigned(?string $pdfFileName, ?string $activitySubject, ?bool $isLiveMode, string $expectedFilename): void {
+    $_REQUEST['cid'] = $this->contactId;
+    $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', [
+      'pdf_file_name' => $pdfFileName,
+      'subject' => $activitySubject,
+      '_contactIds' => [],
+      'document_type' => 'pdf',
+      'buttons' => [
+        '_qf_PDF_upload' => $isLiveMode,
+      ],
+    ]);
+    $fileNameAssigned = NULL;
+    $form->preProcess();
+    try {
+      $form->postProcess();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $fileNameAssigned = $e->errorData['fileName'];
+    }
+
+    $this->assertEquals($expectedFilename, $fileNameAssigned);
+  }
+
+  /**
+   * DataProvider for testFilenameIsAssigned.
+   *
+   * @return array
+   *   Array with the test information.
+   */
+  public function getFilenameCases(): array {
+    return [
+      [
+        'FilenameInParam',
+        'FilenameInActivitySubject',
+        NULL,
+        'FilenameInParam_preview',
+      ],
+      [
+        'FilenameInParam',
+        'FilenameInActivitySubject',
+        TRUE,
+        'FilenameInParam',
+      ],
+      [
+        NULL,
+        'FilenameInActivitySubject',
+        NULL,
+        'FilenameInActivitySubject_preview',
+      ],
+      [
+        NULL,
+        'FilenameInActivitySubject',
+        TRUE,
+        'FilenameInActivitySubject',
+      ],
+      [
+        NULL,
+        NULL,
+        NULL,
+        'CiviLetter_preview',
+      ],
+      [
+        NULL,
+        NULL,
+        TRUE,
+        'CiviLetter',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This PR cherry picked patched commits from 5.35.2-patches for the commits that have not been included with CiviCRM 5.39.1

https://github.com/compucorp/civicrm-core/commits/5.35.2-patches

There are two commits that are not included in this PR that required update patches. List of commits are commented here  https://compucorp.atlassian.net/browse/PROD-13?focusedCommentId=132137

This PR also adds release workflow to the patches branch. 
