### PR TITLE
Revert "BASW-123: Prevent cancelling membership when cancelling linked offline installment contribution

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -616,10 +616,6 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function save($hook = TRUE) {
     $eventID = uniqid();
-    if ($hook) {
-      CRM_Utils_Hook::preSave($this);
-    }
-
     if (!empty($this->id)) {
       if ($hook) {
         $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1580,19 +1580,6 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function preSave(&$dao) {
-    $hookName = 'civicrm_preSave_' . $dao->getTableName();
-    return self::singleton()->invoke(array('dao'), $dao,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      $hookName
-    );
-  }
-
-  /**
-   * @param CRM_Core_DAO $dao
-   *
-   * @return mixed
-   */
   public static function postSave(&$dao) {
     $hookName = 'civicrm_postSave_' . $dao->getTableName();
     return self::singleton()->invoke(['dao'], $dao,


### PR DESCRIPTION
This reverts commit a3930931296ad0a31ba40011e8bb6d4a781ae34e. The reason is that we don't need this patch anymore since
we will depend on disabling contributioncancelactions core extension instead.

See:

- https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/396
- https://github.com/compucorp/compuclient/pull/147