### PR TITLE
PROD-33: Add civicrm_contribution_recur to LineItem supported entity table options

### DIFF
--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -298,6 +298,7 @@ WHERE cc.id IN (' . implode(',', $contactIds) . ') AND con.is_test = 0';
     return [
       'civicrm_line_item' => ts('Line Item'),
       'civicrm_financial_trxn' => ts('Financial Trxn'),
+      'civicrm_contribution_recur' => ts('Recurring Contribution'),
     ];
   }
 

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -1251,6 +1251,7 @@ WHERE li.contribution_id = %1";
       'civicrm_contribution' => ts('Contribution'),
       'civicrm_participant' => ts('Participant'),
       'civicrm_membership' => ts('Membership'),
+      'civicrm_contribution_recur' => ts('Recurring Contribution'),
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM decided to limit the supported entity_table options to some predefined tables as seen in this PR  https://github.com/civicrm/civicrm-core/pull/20464, this is now causing error in our https://github.com/compucorp/uk.co.compucorp.membershipextras as we allow users to add LineItems to civicrm_contribution_recur table which is not part of the predefined tables.

This PR is our short-term solution for now.

Before
----------------------------------------
![343d1bc5-732a-4a6c-bdd7-fb3cee8f9b01](https://user-images.githubusercontent.com/85277674/138888025-5d073926-2211-4e36-9d7c-19a91733f255.gif)

After
----------------------------------------

![after-line-item](https://user-images.githubusercontent.com/85277674/138893330-ad4d7e63-9c46-4894-b88a-384c2321926e.gif)
