### PR TITLE
WHFSPRT-204: CKEditor security upgrade

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -23,6 +23,14 @@ jobs:
           wget https://storage.googleapis.com/civicrm/civicrm-stable/${base_version}/${civi_package}
           tar xzf ./${civi_package} -C to-be-patched
 
+      - name: Ckeditor security upgrade
+        run: |
+          cd ..
+          rm -rf to-be-patched/civicrm/bower_components/ckeditor/
+          wget https://github.com/ckeditor/ckeditor-releases/archive/4.16.2.tar.gz
+          tar xzf 4.16.2.tar.gz
+          mv ckeditor4-releases-4.16.2 to-be-patched/civicrm/bower_components/ckeditor/
+
       - name: Checkout the fork
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Before
----------------------------------------
In this PR: https://github.com/compucorp/compuclient/pull/141

CKeditor was updated to version 5 due to a security vulnerability in the version used in CiviCRM and following one of the options mentioned here: https://civicrm.org/advisory/civi-sa-2021-09-ckeditor-multiple-advisories

But this was causing issues we have in both WHFSPRT-203 and WHFSPRT-204 which make CKeditor almost unusable (specially the issue in WHFSPRT-204 which is also happening in vanilla CiviCRM with CKeditor v5 enabled).

After
----------------------------------------
Here I changed the patching workflow to replace the CiviCRM version of CKeditor directly with an updating version 4 that contains the security fix  (version 4.16.2) and that is suggested by the same document above as alternative to upgrading to version 5 of Ckeditor.

What I do here is  basically downloading the new CKedtiro version with wget, remove the old CKeditor version, extract that new CKeditor version, and move to the old version location which is inside the patched CiviCRM folder.

There will be another PR to Compuclient to switch the setting to use version 4 instead of 5.

Also I already tested the change in this PR in separate temporary branch and compared it with current version that we have, and as it should be only CKeditor and the version info file are different .
![2021-12-08 01_23_39-Settings](https://user-images.githubusercontent.com/6275540/145121358-f7596c20-56d3-4ee9-b505-73ebbaac73ea.png)


