### PR TITLE
COMCL-182: Backport security fixes

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -25,6 +25,12 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
    */
   public function preProcess() {
     $id = $this->get('id');
+
+    // Check permission for action.
+    if (!CRM_Core_Permission::checkActionPermission('CiviContribute', $this->_action)) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    }
+
     $params = ['id' => $id];
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $context);

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -296,11 +296,9 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
       }
       else {
         $eventTitle = $params['event_title'];
-        $qParams = [];
-        $dao = new CRM_Core_DAO();
-        $params['participant_role_id'] = $dao->singleValueQuery("SELECT default_role_id FROM civicrm_event WHERE title = '$eventTitle' ",
-          $qParams
-        );
+        $params['participant_role_id'] = CRM_Core_DAO::singleValueQuery('SELECT default_role_id FROM civicrm_event WHERE title = %1', [
+          1 => [$eventTitle, 'String']
+        ]);
       }
     }
 
@@ -554,11 +552,9 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
           if (!CRM_Utils_Rule::integer($value)) {
             return civicrm_api3_create_error("Event ID is not valid: $value");
           }
-          $dao = new CRM_Core_DAO();
-          $qParams = [];
-          $svq = $dao->singleValueQuery("SELECT id FROM civicrm_event WHERE id = $value",
-            $qParams
-          );
+          $svq = CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_event WHERE id = %1', [
+            1 => [$value, 'Integer']
+          ]);
           if (!$svq) {
             return civicrm_api3_create_error("Invalid Event ID: There is no event record with event_id = $value.");
           }

--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,7 @@
         "ignore": [".*", "node_modules", "docs", "Gruntfile.js", "index.html", "package.json", "test"]
       },
       "ckeditor": {
-        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.16.1.zip"
+        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.18.0.zip"
       },
       "crossfilter-1.3.x": {
         "url": "https://github.com/crossfilter/crossfilter/archive/1.3.14.zip",

--- a/composer.json
+++ b/composer.json
@@ -228,7 +228,7 @@
         "url": "https://github.com/civicrm/jquery/archive/1.12.4-civicrm-1.2.zip"
       },
       "jquery-ui": {
-        "url": "https://github.com/components/jqueryui/archive/1.12.1.zip"
+        "url": "https://github.com/civicrm/jqueryui/archive/1.13.1-civicrm.zip"
       },
       "jquery-validation": {
         "url": "https://github.com/jquery-validation/jquery-validation/archive/1.19.3.zip",


### PR DESCRIPTION
Overview (written by @omarabuhussein)
----------------------------------------
To avoid the complexity of moving to new version of CiviCRM  and how time consuming it is and for the time being, we agreed on a call to backport the security fixes from from here: https://civicrm.org/blog/dev-team/civicrm-5472-5463-5454-esr-security-release to our patched 5.39.1 version. 

These security fixes are:

- [CIVI-SA-2022-01](https://civicrm.org/civicrm/mailing/url?u=18883&qid=1986556):  https://github.com/civicrm/civicrm-core/commit/f91b40e99b24a4457864abc6c9bb3493018ee1e0

- [CIVI-SA-2022-02](https://civicrm.org/civicrm/mailing/url?u=18884&qid=1986556):  https://github.com/civicrm/civicrm-core/commit/d4d1df5b8cffa797a99f01777ce0b406f4fbe2a1

- [CIVI-SA-2022-03](https://civicrm.org/civicrm/mailing/url?u=18885&qid=1986556): No need for it, given it is not a security fix and that we don’t give “access CiviContribute” permission to Anonymous users anyway.

- [CIVI-SA-2022-04](https://civicrm.org/civicrm/mailing/url?u=18886&qid=1986556):  https://github.com/civicrm/civicrm-core/commit/1d48b8dd5f03344a2d7d0ae62bd2b2d1492717c5

- [CIVI-SA-2022-05](https://civicrm.org/civicrm/mailing/url?u=18887&qid=1986556): https://github.com/civicrm/civicrm-core/commit/f9640696edf90cea17c078cb627a9e42800ac5b7