### PR TITLE
COMCL-182: Update ckeditor and jquery ui

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -36,7 +36,7 @@ jobs:
           cd ..
           rm -rf to-be-patched/civicrm/bower_components/jquery-ui/
           wget https://github.com/civicrm/jqueryui/archive/1.13.1-civicrm.tar.gz
-          tar xzf 1.13.1-civicrm.zip
+          tar xzf 1.13.1-civicrm.tar.gz
           mv jqueryui-1.13.1-civicrm to-be-patched/civicrm/bower_components/jquery-ui/
 
       - name: Checkout the fork

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -27,9 +27,17 @@ jobs:
         run: |
           cd ..
           rm -rf to-be-patched/civicrm/bower_components/ckeditor/
-          wget https://github.com/ckeditor/ckeditor-releases/archive/4.16.2.tar.gz
-          tar xzf 4.16.2.tar.gz
-          mv ckeditor4-releases-4.16.2 to-be-patched/civicrm/bower_components/ckeditor/
+          wget https://github.com/ckeditor/ckeditor-releases/archive/4.18.0.tar.gz
+          tar xzf 4.18.0.tar.gz
+          mv ckeditor4-releases-4.18.0 to-be-patched/civicrm/bower_components/ckeditor/
+
+      - name: jqueryUI security upgrade
+        run: |
+          cd ..
+          rm -rf to-be-patched/civicrm/bower_components/jquery-ui/
+          wget https://github.com/civicrm/jqueryui/archive/1.13.1-civicrm.tar.gz
+          tar xzf 1.13.1-civicrm.zip
+          mv jqueryui-1.13.1-civicrm to-be-patched/civicrm/bower_components/jquery-ui/
 
       - name: Checkout the fork
         uses: actions/checkout@v2


### PR DESCRIPTION
Overview
----------------------------------------
This PR updates jqueryui and ckeditor to latest version with security updates
jqueryui from version `1.12.1` to `1.13.1`
CKEditor from version `4.16.1 `to `4.18.0`

This updates are done in the patch workflow directly because the patch workflow doesn't use the composer.json file to fetch packages.