### PR TITLE
COMCL-221: Fix CIVI-SA-2022-07 security patch regression 

### DIFF
--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -182,7 +182,7 @@ class ChainSubscriber implements EventSubscriberInterface {
           $enforcedSubParams['version'] = $version;
           // Copy check_permissions from parent.
           $enforcedSubParams['check_permissions'] = $params['check_permissions'] ?? NULL;
-          $enforcedSubParams['sequential'] = 1;
+          $defaultSubParams['sequential'] = 1;
           $enforcedSubParams['api.has_parent'] = 1;
           // Inspect $newparams, the passed in params for the chain call.
           if (array_key_exists(0, $newparams)) {


### PR DESCRIPTION
Overview
----------------------------------------
The security fix in CIVI-SA-2022-07  (https://civicrm.org/advisory/civi-sa-2022-07-apiv3-access-bypass) introduced a regression, this PR applies the the fix for this regression: https://github.com/civicrm/civicrm-core/pull/23672/
