### PR TITLE
MAE-887: Applying civicrm/civicrm-core/pull/24221

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -40,8 +40,9 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    * @throws \Exception
    */
   public static function create(&$params) {
-    // This is the database default
-    $params += ['extends' => 'Contact'];
+    if (empty($params['id'])) {
+      $params += ['extends' => 'Contact'];
+    }
     // create custom group dao, populate fields and then save.
     $group = new CRM_Core_DAO_CustomGroup();
     if (isset($params['title'])) {


### PR DESCRIPTION
Overview
----------------------------------------

The error reported  in this PR: https://github.com/civicrm/civicrm-core/pull/24221 is the reason why many of Membershipextras tests are failing, specially the ones related to Autorenewal:

```
5) CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest::testRenewalWillCreateCorrectSubscriptionLineItems
CRM_Core_Exception: One of parameters  (value: ) is not of the type Integer

/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/CRM/Utils/Type.php:[46](https://github.com/compucorp/uk.co.compucorp.membershipextras/actions/runs/3099046487/jobs/5017706963#step:8:47)9
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/CRM/Core/DAO.php:1737
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/CRM/Core/DAO.php:1619
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php:741
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php:399
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598

6) CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest::testRenewingUpgradableMembershipWithWillCreateCorrectSubscriptionLineItems
CRM_Core_Exception: One of parameters  (value: ) is not of the type Integer

/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/CRM/Utils/Type.php:469
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/CRM/Core/DAO.php:1737
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/CRM/Core/DAO.php:1619
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php:741
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php:669
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598

7) CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlanTest::testRenewingUpgradableMembershipWithWillCreateUpgradedMembershipAndEndCurrentOne
Undefined array key 1

/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlanTest.php:[50](https://github.com/compucorp/uk.co.compucorp.membershipextras/actions/runs/3099046487/jobs/5017706963#step:8:51)9
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:[59](https://github.com/compucorp/uk.co.compucorp.membershipextras/actions/runs/3099046487/jobs/5017706963#step:8:60)8

```

The reason is before running the tests, when install the extension that we are running the tests for (Membershipextras in this case), and when installing extensions Civi will run the Upgrader `install()` and `postInstall()` functions, then it will run `enable()` https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/5.2.0/CRM/MembershipExtras/Upgrader.php#L33, this does not cause issues usually given that we mostly activate some entities inside `enable()` function, but because of the error reported in the PR above, trying to activate Membershipextras custom groups : https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/5.2.0/CRM/MembershipExtras/Setup/Manage/CustomGroup/PaymentPlanExtraAttributes.php#L42
will result in changing them from being extending their correct entities, to be extending the Contact entity.

I could have potentially solved this in Membershipextras, but given it might end up affectign a lot of extensions and existing functionalities, and how risky this issue is, It is much safer to apply the patch on CiviCMR itself.