### PR TITLE
CIVIIB-46: Applying 2023-01-05 security patches

### DIFF
--- a/CRM/Core/Page/Inline/Help.php
+++ b/CRM/Core/Page/Inline/Help.php
@@ -21,9 +21,10 @@ class CRM_Core_Page_Inline_Help {
 
   public function run() {
     $args = $_REQUEST;
-    if (!empty($args['file']) && strpos($args['file'], '..') === FALSE) {
-      $file = $args['file'] . '.hlp';
-      $additionalTPLFile = $args['file'] . '.extra.hlp';
+    $file = (string) ($args['file'] ?? '');
+    if (preg_match('@^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)*$@', $file)) {
+      $additionalTPLFile = "$file.extra.hlp";
+      $file .= '.hlp';
       $smarty = CRM_Core_Smarty::singleton();
       $smarty->assign('id', $args['id']);
       CRM_Utils_Array::remove($args, 'file', 'class_name', 'type', 'q', 'id');
@@ -41,7 +42,11 @@ class CRM_Core_Page_Inline_Help {
           $output = '';
         }
       }
-      exit($output . $extraoutput);
+      echo trim($output . $extraoutput);
+      CRM_Utils_System::civiExit();
+    }
+    else {
+      throw new CRM_Core_Exception('File name is not valid');
     }
   }
 

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -117,14 +117,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
 
       $participantListingID = $eventInfo['participant_listing_id'] ?? NULL;
       //CRM_Core_DAO::getFieldValue( 'CRM_Event_DAO_Event', $this->_id, 'participant_listing_id' );
-      if ($participantListingID) {
-        $participantListingURL = CRM_Utils_System::url('civicrm/event/participant',
-          "reset=1&id={$this->_id}",
-          TRUE, NULL, TRUE, TRUE
-        );
-        $this->assign('participantListingURL', $participantListingURL);
-      }
-
+      $this->assign('participantListingID', $participantListingID);
       $this->assign('isOnlineRegistration', CRM_Utils_Array::value('is_online_registration', $eventInfo));
 
       $this->assign('id', $this->_id);

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -368,7 +368,18 @@ class AssetBuilder {
   public static function pageRender($get) {
     // Beg your pardon, sir. Please may I have an HTTP response class instead?
     try {
+      /** @var Assetbuilder $assets */
       $assets = \Civi::service('asset_builder');
+
+      $expectDigest = $assets->digest($get['an'], $assets->decode($get['ap']));
+      if ($expectDigest !== $get['ad']) {
+        return [
+          'statusCode' => 500,
+          'mimeType' => 'text/plain',
+          'content' => 'Invalid digest',
+        ];
+      }
+
       return $assets->render($get['an'], $assets->decode($get['ap']));
     }
     catch (UnknownAssetException $e) {

--- a/templates/CRM/Contact/Form/Search/Basic.hlp
+++ b/templates/CRM/Contact/Form/Search/Basic.hlp
@@ -20,7 +20,7 @@
   {ts}Group Search{/ts}
 {/htxt}
 {htxt id="id-smog-criteria"}
-    <p>{ts 1=$params.group_title}Contacts in the <strong>%1</strong> group are listed below.{/ts}
+    <p>{ts 1=$params.group_title|smarty:nodefaults|escape}Contacts in the <strong>%1</strong> group are listed below.{/ts}
       <ul>
         <li>{ts}Use 'Find Contacts within this Group' to search for specific contacts.{/ts}</li>
         <li>{ts}Use the 'Group Status...' checkboxes to view contacts with 'Pending' status and/or contacts who have been 'Removed' from this group.{/ts}</li>
@@ -32,7 +32,7 @@
   {ts}Add to Group{/ts}
 {/htxt}
 {htxt id="id-amtg-criteria"}
-    {ts 1=$params.group_title}Use this Search form to find contacts. Mark the contacts you want to add to this group. Then click 'Add Contacts to %1'.{/ts}
+    {ts 1=$params.group_title|smarty:nodefaults|escape}Use this Search form to find contacts. Mark the contacts you want to add to this group. Then click 'Add Contacts to %1'.{/ts}
 {/htxt}
 
 {htxt id="id-edit-smartGroup-title"}

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
@@ -48,7 +48,7 @@
           {ts}After adding your event, create links to the listing page by copying the URL provided in the 'Participant Listing' section of the Configure Event page.{/ts}
         {/if}
       {elseif $config->userFramework EQ 'Joomla'}
-          {ts 1=$params.entityId}Then create front-end links to the Participant Listing page using the Menu Manager. Select <strong>Participant Listing Page</strong> and enter <strong>%1</strong> for the Event ID.{/ts}
+          {ts 1=$params.entityId|smarty:nodefaults|escape}Then create front-end links to the Participant Listing page using the Menu Manager. Select <strong>Participant Listing Page</strong> and enter <strong>%1</strong> for the Event ID.{/ts}
       {/if}
     {/if}
 {/htxt}
@@ -84,14 +84,14 @@
   {ts}Waitlist Text{/ts}
 {/htxt}
 {htxt id="id-help-waitlist_text"}
-{ts}This message is displayed on the event information and event registration pages when the event is full AND the waitlist feature is enabled.{/ts} 
+{ts}This message is displayed on the event information and event registration pages when the event is full AND the waitlist feature is enabled.{/ts}
 {/htxt}
 
 {htxt id="id-is_map-title"}
   {ts}Map{/ts}
 {/htxt}
 {htxt id="id-is_map"}
-{capture assign=mapURL}{crmURL p='civicrm/admin/setting/mapping' q="reset=1"}{/capture} 
+{capture assign=mapURL}{crmURL p='civicrm/admin/setting/mapping' q="reset=1"}{/capture}
 {ts 1=$mapURL}Include map presenting event location on event information page? (A map provider must be configured under <a href='%1'>Administer > System Settings > Mapping and Geocoding</a>){/ts}
 {/htxt}
 

--- a/templates/CRM/Event/Form/ManageEvent/Tab.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Tab.hlp
@@ -35,12 +35,14 @@
 
 {if !$params.isTemplate}
     <tr>
-    {if $params.participantListingURL}
-        <td><a href="{$params.participantListingURL}" id="idParticipantListing"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Participant Listing{/ts}</a></td>
+    {if $params.participantListingID}
+        {capture name=participantListingURL assign=participantListingURL}{crmURL p='civicrm/event/participant' q="reset=1&force=1&id=`$params.eventId`&status=true" a="true" fe="true"}{/capture}
+        <td><a href="{$participantListingURL}" id="idParticipantListing"><i class="crm-i fa-chevron-right" aria-hidden="true"></i>{ts}Participant Listing{/ts}</a></td>
+{*        <td><a href="{crmURL p='civicrm/event/participant' q="reset=1&force=1&id=`$params.eventId`status=true" a="true" fe="true"}" id="idParticipantListing"><i class="crm-i fa-chevron-right" aria-hidden="true"></i>{ts}Participant Listing{/ts}</a></td>*}
         {if $config->userSystem->is_drupal}
-          <td>{ts 1=$params.participantListingURL}The following URL will display a list of registered participants for this event to users whose role includes "view event participants" permission: <a href="%1">%1</a>{/ts}</td>
+          <td>{ts 1=$participantListingURL}The following URL will display a list of registered participants for this event to users whose role includes "view event participants" permission: <a href="%1">%1</a>{/ts}</td>
         {else}
-          <td>{ts 1=$params.participantListingURL}The following URL will display a list of registered participants for this event: <a href="%1">%1</a>{/ts}</td>
+          <td>{ts 1=$participantListingURL}The following URL will display a list of registered participants for this event: <a href="%1">%1</a>{/ts}</td>
         {/if}
     {else}
         <td><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Participant Listing{/ts}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Tab.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Tab.tpl
@@ -48,7 +48,7 @@
         </div></li>
 
       <li><div>
-          {help id="id-configure-events" isTemplate=$isTemplate participantListingURL=$participantListingURL isOnlineRegistration=$isOnlineRegistration eventId=$id}
+          {help id="id-configure-events" isTemplate=$isTemplate participantListingID=$participantListingID isOnlineRegistration=$isOnlineRegistration eventId=$id}
       </div></li>
       </ul>
       <div class="clear"></div>


### PR DESCRIPTION
## Overview

Here I am applying the security patches included in this CiviCRM security release:

https://civicrm.org/blog/dev-team/civicrm-5570-5562-5514-esr-security-release

which consist of 3 patches:

1- https://civicrm.org/advisory/civi-sa-2023-01-help-subsystem-rce
2- https://civicrm.org/advisory/civi-sa-2023-02-civievent-xss
3- https://civicrm.org/advisory/civi-sa-2023-03-asset-builder-xss

I got the code for these patches from here:

https://github.com/civicrm/civicrm-core/compare/5.56.1...5.56.2?expand=1

which is basically comparing CiviCRM 5.56.2 against 5.56.1, since 5,56.2 is same as 5.56.1 + security patches.