### PR TITLE
CIVIIB-122: Apply a patch that correctly handle empty arrays in custom-fields

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1110,7 +1110,7 @@ function _civicrm_api3_custom_format_params($params, &$values, $extends, $entity
   foreach ($params as $key => $value) {
     [$customFieldID, $customValueID] = CRM_Core_BAO_CustomField::getKeyID($key, TRUE);
     if ($customFieldID && (!is_null($value))) {
-      if ($checkCheckBoxField && !empty($fields['custom_' . $customFieldID]) && $fields['custom_' . $customFieldID]['html_type'] == 'CheckBox') {
+      if ($checkCheckBoxField && isset($fields['custom_' . $customFieldID]) && $fields['custom_' . $customFieldID]['html_type'] == 'CheckBox') {
         formatCheckBoxField($value, 'custom_' . $customFieldID, $entity);
       }
 
@@ -1180,6 +1180,10 @@ function formatCheckBoxField(&$checkboxFieldValue, $customFieldLabel, $entity) {
     return;
   }
 
+  if (is_array($checkboxFieldValue) && empty($checkboxFieldValue)) {
+    $checkboxFieldValue = '';
+    return;
+  }
   $options = $options['values'];
   $validValue = TRUE;
   if (is_array($checkboxFieldValue)) {


### PR DESCRIPTION
Overview
----------------------------------------

This PR adds a commit that fixed a fatal error in PHP 8.0 when passing an empty array to a custom checkboxes/select field. https://lab.civicrm.org/dev/core/-/issues/3942

The commit was cherry-picked from CiviCRM core in this PR https://github.com/civicrm/civicrm-core/pull/23305