### PR TITLE
BTHAB-101: Apply patch to fix date range filters for search displays

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -96,7 +96,7 @@
 
       getAfformFilters: function() {
         return _.pick(this.afFieldset ? this.afFieldset.getFieldData() : {}, function(val) {
-          return val !== null && (_.includes(['boolean', 'number'], typeof val) || val.length);
+          return val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length);
         });
       },
 


### PR DESCRIPTION
## Overview
This pull request (PR) applies an update from this [PR](https://github.com/civicrm/civicrm-core/pull/24451) to the fork as a patch. It addresses the issue where the search kit date filter was not functioning as expected on an afform display.


## Comment
Included in CiviCRM 5.54.0
PR: https://github.com/civicrm/civicrm-core/pull/24451