### PR TITLE
GIZ-226: Allow user to configure donotreply email address

### DIFF
--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -22,6 +22,7 @@ class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
 
   protected $_settings = [
     'profile_double_optin' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
+    'no_reply_email_address' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'profile_add_to_group_double_optin' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'track_civimail_replies' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'civimail_workflow' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
@@ -60,6 +61,18 @@ class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
     }
 
     parent::postProcess();
+  }
+
+  /**
+   * @return array
+   */
+  public static function getAvailableFromEmailAddresses() {
+    $fromAddress[NULL] = ts('');
+    $addresses = CRM_Core_OptionGroup::values('from_email_address');
+    foreach ($addresses as $key => $value) {
+      $fromAddress[$key] = $value;
+    }
+    return $fromAddress;
   }
 
 }

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -370,7 +370,14 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    */
   public static function getNoReplyEmailAddress() {
     $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
-    return "do-not-reply@$emailDomain";
+    $notReplyEmailAddress = \Civi::settings()->get('no_reply_email_address');
+
+    if (!empty($notReplyEmailAddress)) {
+      $notReplyEmailAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND value = ' . $notReplyEmailAddress);
+      $notReplyEmailAddress = current($notReplyEmailAddress);
+    }
+
+    return $notReplyEmailAddress ?: "do-not-reply@$emailDomain";
   }
 
 }

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -33,6 +33,28 @@ return [
     'description' => ts('When CiviMail is enabled, users who "subscribe" to a group from a profile Group(s) checkbox will receive a confirmation email. They must respond (opt-in) before they are added to the group.'),
     'help_text' => NULL,
   ],
+  'no_reply_email_address' => [
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'no_reply_email_address',
+    'type' => 'String',
+    'quick_form_type' => 'Select',
+    'html_type' => 'select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'default' => NULL,
+    'pseudoconstant' => [
+      'callback' => 'CRM_Admin_Form_Preferences_Mailing::getAvailableFromEmailAddresses',
+    ],
+    'add' => '5.63',
+    'title' => ts('Email From Address to use where a reply is not expected'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => '',
+    'help_text' => NULL,
+    'help' => ['id' => 'no_reply_email_address'],
+  ],
   'track_civimail_replies' => [
     'group_name' => 'Mailing Preferences',
     'group' => 'mailing',

--- a/templates/CRM/Admin/Form/Preferences/Mailing.hlp
+++ b/templates/CRM/Admin/Form/Preferences/Mailing.hlp
@@ -1,0 +1,18 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="no_reply_email_address-title"}
+  {ts}Email From Address for no-reply emails.{/ts}
+{/htxt}
+{htxt id="no_reply_email_address"}
+  {capture assign=fromEmailOptionsURL}{crmURL p='civicrm/admin/options/from_email_address' q="reset=1"}{/capture} 
+  <p>{ts 1=$fromEmailOptionsURL}Specify an Email From Address to use when the system sends an email but a reply is not expected, for example when a user is sent an email for a double opt-in.</p>
+  <p>Leaving this blank will use the default which will be do-not-reply@default_domain where the default_domain will be the email domain address of your default mailing account also used for bounce handling.</p>
+  <p>You can add additional Email From Addresses <a href='%1'>here</a>.{/ts}</p>
+{/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
This pull request (PR) applies an update from this [PR](https://github.com/civicrm/civicrm-core/pull/26180) to the fork as a patch. It allows users to configure which email address to use as the do not reply email.

Core PR: https://github.com/civicrm/civicrm-core/pull/26180

