### PR TITLE
FOSFAB-135: Set default created_id for case and activity Attachments

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -149,6 +149,9 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
       $fileDAO->id = $dao->cfID;
       unlink($directoryName . DIRECTORY_SEPARATOR . $dao->uri);
     }
+    elseif (empty($fileParams['created_id'])) {
+      $fileDAO->created_id = CRM_Core_Session::getLoggedInContactID();
+    }
 
     if (!empty($fileParams)) {
       $fileDAO->copyValues($fileParams);


### PR DESCRIPTION
Overview
----------------------------------------
We are applying the patch from this https://github.com/civicrm/civicrm-core/pull/26409 PR to the fork. This is needed so that Civi can save the uploader name and we can use/show it.
