### PR TITLE
CST-209: Don't crash ContributionView when participant fields are null

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -126,14 +126,14 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       $participantLineItems = [];
     }
 
-    $associatedParticipants = FALSE;
+    $associatedParticipants = empty($participantLineItems) ? FALSE : [];
     foreach ($participantLineItems as $participant) {
       $associatedParticipants[] = [
         'participantLink' => CRM_Utils_System::url('civicrm/contact/view/participant',
           "action=view&reset=1&id={$participant['entity_id']}&cid={$participant['participant.contact_id']}&context=home"
         ),
         'participantName' => $participant['contact.display_name'],
-        'fee' => implode(', ', $participant['participant.fee_level']),
+        'fee' => implode(', ', $participant['participant.fee_level'] ?? []),
         'role' => implode(', ', $participant['participant.role_id:label']),
       ];
     }


### PR DESCRIPTION
Overview
----------------------------------------
This pull request (PR) applies an update from this https://github.com/civicrm/civicrm-core/pull/24906 to the fork as a patch.



## Comment
Included in CiviCRM 5.62.1
PR: https://github.com/civicrm/civicrm-core/pull/24906