### PR TITLE
COMCL-571: Add missing Smarty getversion method

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -458,4 +458,28 @@ class CRM_Core_Smarty extends Smarty {
     return $value;
   }
 
+  public function getVersion (): int {
+    static $version;
+    if ($version === NULL) {
+      if (class_exists('Smarty\Smarty')) {
+        $version = 5;
+      }
+      else {
+        $class = new ReflectionClass('Smarty');
+        $path = $class->getFileName();
+        if (str_contains($path, 'smarty3')) {
+          $version = 3;
+        }
+        elseif (str_contains($path, 'smarty4')) {
+          $version = 4;
+        }
+        else {
+          $version = 2;
+        }
+      }
+    }
+    return $version;
+
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This security patch [PR](https://github.com/compucorp/civicrm-core/pull/125) required the method `CRM_Core_smarty::getVersion()` that we don't have. In this PR we have added it.

Included in CiviCRM 5.74.04
PR: https://github.com/civicrm/civicrm-core/pull/30286, https://github.com/civicrm/civicrm-core/pull/30508