### PR TITLE
COMCL-593: Register Smarty_UserContentPolicy service manually

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -213,6 +213,11 @@ class Container {
       []
     ))->setPublic(TRUE);
 
+    $container->setDefinition('civi.smarty.userContent', new Definition(
+      'CRM_Core_Smarty_UserContentPolicy',
+      []
+    ))->setPublic(TRUE);
+
     $container->setDefinition('themes', new Definition(
       'Civi\Core\Themes',
       []


### PR DESCRIPTION
Overview
----------------------------------------
We are registering this service manually because the auto-service (by ID) doesn't work as expected in the current version (5.51.3).

It is not clear in what version this was fixed, different fixes from different PRs didn't resolve the issue, so we have instead register this class manually in the container.

Included in CivICRM 5.75 - This is the CiviCRM version we are sure this is working as expected, given that that is when the class `CRM_Core_Smarty_UserContentPolicy` was introduced (https://github.com/civicrm/civicrm-core/pull/30508)

## Before
The error above was thrown
```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: "You have requested a non-existent service "civi.smarty.userContent"."
```

## After
The error is no longer thrown
