### PR TITLE
COMCL-603: Fix Cache Issue In Schema Difference Calculation For Log Tables

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -427,8 +427,10 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    *   name of the relevant table.
    * @param array $cols
    *   Mixed array of columns to add or null (to check for the missing columns).
+   * @param bool $resetTableCache
+   *   Refresh the cache for table before calculating the differences with log table.
    */
-  public function fixSchemaDifferencesFor(string $table, array $cols = []): void {
+  public function fixSchemaDifferencesFor(string $table, array $cols = [], bool $resetTableCache = FALSE): void {
     if (!in_array($table, $this->tables, TRUE)) {
       // Create the table if the log table does not exist and
       // the table is in 'this->tables'. This latter array
@@ -441,13 +443,17 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
       return;
     }
 
+    if ($resetTableCache) {
+      $this->resetSchemaCacheForTable($table);
+    }
+    $this->resetSchemaCacheForTable("log_$table");
+
     if (empty($cols)) {
       $cols = $this->columnsWithDiffSpecs($table, "log_$table");
     }
 
     // If a column that already exists on logging table is being added, we
     // should treat it as a modification.
-    $this->resetSchemaCacheForTable("log_$table");
     $logTableSchema = $this->columnSpecsOf("log_$table");
     if (!empty($cols['ADD'])) {
       foreach ($cols['ADD'] as $colKey => $col) {

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -391,7 +391,7 @@ class CRM_Upgrade_Incremental_Base {
       }
       $schema = new CRM_Logging_Schema();
       if ($schema->isEnabled()) {
-        $schema->fixSchemaDifferencesFor($table);
+        $schema->fixSchemaDifferencesFor($table, [], TRUE);
       }
     }
     if ($locales && $triggerRebuild) {
@@ -613,7 +613,7 @@ class CRM_Upgrade_Incremental_Base {
     }
     $schema = new CRM_Logging_Schema();
     if ($schema->isEnabled()) {
-      $schema->fixSchemaDifferencesFor($table);
+      $schema->fixSchemaDifferencesFor($table, [], TRUE);
     }
     $locales = CRM_Core_I18n::getMultilingual();
     if ($locales) {
@@ -720,7 +720,7 @@ class CRM_Upgrade_Incremental_Base {
     }
     $schema = new CRM_Logging_Schema();
     if ($schema->isEnabled()) {
-      $schema->fixSchemaDifferencesFor($table);
+      $schema->fixSchemaDifferencesFor($table, [], TRUE);
     }
     if ($locales) {
       CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, NULL, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
This pr solves a very specific caching related to calculation of schema difference between a table and its log table. Below is an example of a scenario that could be introduced due to the bug that is fixed in this pr.

During a civicrm upgrade in one of the updates civi modifies name of the column and on each such operation civi calculates the difference between original table and table's log table and apply any changes to the log table but the problem here is that the changes somehow are not saved correctly in table cache for the original table and in cache both the columns exist one with old name and one with updated name so in a later update if civi does the changes again to this same table and now when civi attempts to find the differences between log and original table the columns with old names appears to be missing from log table then civi tries to get the column definition by querying information schema and it finds nothing and the query for adding columns to log table is not created correctly or is incomplete and it throws error.

To fix this this pr always refreshes table cache before calculating the schema differences.
