### PR TITLE
COMCL-741: Fix Credit Note Allocations For Contributions Without Line Items

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -596,7 +596,7 @@ class CRM_Financial_BAO_Payment {
       $payableItems[$payableItemIndex] = $item;
     }
 
-    if (empty($lineItemOverrides) && !empty($ratio)) {
+    if (empty($lineItemOverrides) && !empty($ratio) && isset($payableItems[$payableItemIndex])) {
       $totalTaxAllocation = array_sum(array_column($payableItems, 'tax_allocation'));
       $totalAllocation = array_sum(array_column($payableItems, 'allocation'));
       $total = $totalTaxAllocation + $totalAllocation;


### PR DESCRIPTION
Overview
----------------------------------------
This pr fixes the credit note allocation to invoices that does not have any line items although its a very rare possibility.

Before
----------------------------------------
Credit note allocation for such contributions were resulting in an error
<img width="1792" alt="Screenshot 2024-08-27 at 1 04 17 PM" src="https://github.com/user-attachments/assets/ffc2f946-976a-443a-ba9e-3558ba59680e">

After
----------------------------------------
Users are able to allocate credit for contributions regardless of if the contribution have any line item or not.