### PR TITLE
CSTMM-37: Fix inavalid price field alert

### DIFF
--- a/CRM/Utils/Check/Component/PriceFields.php
+++ b/CRM/Utils/Check/Component/PriceFields.php
@@ -10,6 +10,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Psr\Log\LogLevel;
+
 /**
  *
  * @package CRM
@@ -27,6 +29,17 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
       INNER JOIN civicrm_price_field psf ON psf.price_set_id = ps.id
       INNER JOIN civicrm_price_field_value pfv ON pfv.price_field_id = psf.id
       LEFT JOIN civicrm_financial_type cft ON cft.id = pfv.financial_type_id
+      INNER JOIN civicrm_price_set_entity pse ON entity_table = 'civicrm_contribution_page' AND ps.id = pse.price_set_id
+      INNER JOIN civicrm_contribution_page cp ON cp.id = pse.entity_id AND cp.is_active = 1
+      WHERE cft.id IS NULL OR cft.is_active = 0
+      UNION
+      SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label
+      FROM civicrm_price_set ps
+      INNER JOIN civicrm_price_field psf ON psf.price_set_id = ps.id
+      INNER JOIN civicrm_price_field_value pfv ON pfv.price_field_id = psf.id
+      LEFT JOIN civicrm_financial_type cft ON cft.id = pfv.financial_type_id
+      INNER JOIN civicrm_price_set_entity pse ON entity_table = 'civicrm_event' AND ps.id = pse.price_set_id
+      INNER JOIN civicrm_event ce ON ce.id = pse.entity_id AND ce.is_active = 1
       WHERE cft.id IS NULL OR cft.is_active = 0";
     $dao = CRM_Core_DAO::executeQuery($sql);
     $count = 0;
@@ -39,20 +52,20 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
         'action' => 'browse',
         'sid' => $dao->ps_id,
       ]);
-      $html .= "<tr><td>$dao->ps_title</td><td>$dao->psf_label</td><td><a href='$url'>View Price Set Fields</a></td></tr>";
+      $html .= "<tr><td>$dao->ps_title</td><td>$dao->psf_label</td><td><a href='$url'>" . ts('View Price Set Fields') . '</a></td></tr>';
     }
     if ($count > 0) {
-      $msg = "<p>the following Price Set Fields use disabled or invalid financial types and need to be fixed if they are to still be used.<p>
-          <p><table><thead><tr><th>Price Set</th><th>Price Set Field</th><th>Action Link</th>
-          </tr></thead><tbody>
-          $html
-          </tbody></table></p>";
+      $msg = '<p>' . ts('The following Price Set Fields use disabled or invalid financial types and need to be fixed if they are to still be used.') . '<p>'
+        . '<p><table><thead><tr><th>' . ts('Price Set') . '</th><th>' . ts('Price Set Field') . '</th><th>' . ts('Action') . '</th>'
+        . '</tr></thead><tbody>'
+        . $html
+        . '</tbody></table></p>';
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-       ts($msg),
-       ts('Invalid Price Fields'),
-       \Psr\Log\LogLevel::WARNING,
-       'fa-lock'
+        $msg,
+        ts('Invalid Price Fields'),
+        LogLevel::WARNING,
+        'fa-lock'
       );
     }
     return $messages;


### PR DESCRIPTION
Overview
----------------------------------------
This pr backport changes to 5.51.3 from [28322](https://github.com/civicrm/civicrm-core/pull/28322) which is included in 5.69.0 .It fixes an issue where an error message was shown to admin users when they first login to civicrm. The error message was due to a large text was being displayed as an alert that was related to all invalid price fields. This pr fixes this issue to show alerts only about price sets that are being used actively.

Before
----------------------------------------
![screen_recording_before](https://github.com/user-attachments/assets/b83ceaa5-1643-488d-bdfc-8c29b0746a39)


After
----------------------------------------
![screen_recording_after](https://github.com/user-attachments/assets/ed3ff5a1-f48b-4578-bd4a-2798389bf422)
