### PR TITLE
NEUSPRT-266: Optimize log viewing for a contact

### DIFF
--- a/CRM/Contact/Page/View/Log.php
+++ b/CRM/Contact/Page/View/Log.php
@@ -33,6 +33,7 @@ class CRM_Contact_Page_View_Log extends CRM_Core_Page {
     }
 
     $log = new CRM_Core_DAO_Log();
+    $modifiers = [];
 
     $log->entity_table = 'civicrm_contact';
     $log->entity_id = $this->_contactId;
@@ -41,11 +42,15 @@ class CRM_Contact_Page_View_Log extends CRM_Core_Page {
 
     $logEntries = [];
     while ($log->fetch()) {
-      list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($log->modified_id);
+      if ($log->modified_id && !isset($modifiers[$log->modified_id])) {
+        $displayInfo = CRM_Contact_BAO_Contact::getDisplayAndImage($log->modified_id);
+        $modifiers[$log->modified_id] = ['name' => $displayInfo[0] ?? '', 'image' => $displayInfo[1] ?? ''];
+      }
+
       $logEntries[] = [
         'id' => $log->modified_id,
-        'name' => $displayName,
-        'image' => $contactImage,
+        'name' => $log->modified_id && $modifiers[$log->modified_id]['name'] ? $modifiers[$log->modified_id]['name'] : '',
+        'image' => $log->modified_id && $modifiers[$log->modified_id]['image'] ? $modifiers[$log->modified_id]['image'] : '',
         'date' => $log->modified_date,
       ];
     }


### PR DESCRIPTION
Overview
----------------------------------------
This pr optimizes the code for viewing the change logs for a contact.

Technical Details
----------------------------------------
Currently during fetching the change log for a contact we also fetch information for modifier contact [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/Page/View/Log.php#L50) once for each row from the log table. This can give timeout errors on big databases as each call to the function [getDisplayAndImage](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/Contact.php#L575) results in one query being executed. Even if same modifier changed the one contact multiple times we will have multiple queries for fetching same information for same modifier.

This pr changes the code to store the modifier information in an array and only query the modifier info if its not already available in the array thus results in significantly lesser number of queries for large change logs.