### PR TITLE
CSTMM-44: Fixes Credit Note Allocation To Taxable Line Items

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -574,11 +574,10 @@ class CRM_Financial_BAO_Payment {
         else {
           $lineItems[$lineItemID]['allocation'] = round($lineItems[$lineItemID]['balance'] * $ratio, 2);
         }
+      }
 
-        if (!empty($lineItem['tax_amount'])) {
-          $lineItems[$lineItemID]['tax_allocation'] = round($lineItem['tax_amount'] * ($params['total_amount'] / $contribution['total_amount']), 2);
-        }
-
+      if (!empty($lineItem['tax_amount'])) {
+        $lineItems[$lineItemID]['tax_allocation'] = round($lineItem['tax_amount'] * ($params['total_amount'] / $contribution['total_amount']), 2);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently when user tries to allocate credit note amount to contribution that have line items with tax the user is redirected to an error page.

Before
----------------------------------------
User sees this error upon allocation
<img width="1321" alt="Screenshot 2024-10-02 at 14 24 53" src="https://github.com/user-attachments/assets/73171ac1-0e59-4c1c-bc42-c15e9d554e04">

After
----------------------------------------
User is able to allocate the credit note successfully
![screen_recording_after](https://github.com/user-attachments/assets/ca8d47b5-1203-4187-8b3c-1f708f9b117a)

Technical Details
----------------------------------------
In this pr https://github.com/civicrm/civicrm-core/pull/29823, we added the support for adding accounting entries for taxable line items while creating payment, but the scenario where a line item data is overridden by payment creation params was not handled correctly for taxable line items. So if a line item that has tax and its overridden as well then it was not getting the tax calculation done. This pr fixes the issue by doing the tax calculation for line items regardless of the fact that whether they have tax or not.
