### PR TITLE
PROD-229: Resolve Issue with Payment Allocation to Contribution Line Item

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -588,22 +588,32 @@ class CRM_Financial_BAO_Payment {
         else {
           $item['allocation'] = round($item['balance'] * $ratio, 2);
         }
-
-        if (!empty($item['tax_amount'])) {
-          $item['tax_allocation'] = round($item['tax_amount'] * ($params['total_amount'] / $contribution['total_amount']), 2);
-        }
       }
       $payableItems[$payableItemIndex] = $item;
     }
 
+    // Custom patch to correct roundoff errors 
     if (empty($lineItemOverrides) && !empty($ratio) && isset($payableItems[$payableItemIndex])) {
-      $totalTaxAllocation = array_sum(array_column($payableItems, 'tax_allocation'));
-      $totalAllocation = array_sum(array_column($payableItems, 'allocation'));
+      $totalTaxAllocation = 0;
+      $totalAllocation = 0;
+      $lastNonTaxKey = $payableItemIndex;
+    
+      foreach ($payableItems as $key => $item) {
+        if ($item['financial_item.financial_account_id.is_tax']) {
+          $totalTaxAllocation += $item['allocation'];
+        }
+        else {
+          $totalAllocation += $item['allocation'];
+          $lastNonTaxKey = $key;
+        }
+      }
+      
       $total = $totalTaxAllocation + $totalAllocation;
       $leftPayment = $params['total_amount'] - $total;
-
-      // assign any leftover amount, to the last lineitem
-      $payableItems[$payableItemIndex]['allocation'] += $leftPayment;
+    
+      if ($lastNonTaxKey !== NULL) {
+        $payableItems[$lastNonTaxKey]['allocation'] += $leftPayment;
+      }
     }
 
     return $payableItems;


### PR DESCRIPTION
Overview
----------------------------------------
In this PR https://github.com/compucorp/civicrm-core/pull/129, we introduced a patch that was previously added to CiviCRM 5.51.3 In [PR](https://github.com/compucorp/civicrm-core/pull/122), but we didn't update the logic to ensure it works as expected in CiviCRM 5.75 with other code changes.

We have an issue with the tax amount showing negative values, as seen below, and with wrong values.

Before
----------------------------------------
<img width="1940" alt="image" src="https://github.com/user-attachments/assets/494a7725-60e5-4c8a-8822-8f1e5ab7d472">

After
----------------------------------------
<img width="1895" alt="image" src="https://github.com/user-attachments/assets/df96ba5f-673e-4e64-aafb-2fa9f15eaa7f">
