### PR TITLE
MCSPRT-417: aAjax batchSave() method should be static, php8 compatibility

### DIFF
--- a/CRM/Batch/Page/AJAX.php
+++ b/CRM/Batch/Page/AJAX.php
@@ -23,7 +23,7 @@ class CRM_Batch_Page_AJAX {
   /**
    * Save record.
    */
-  public function batchSave() {
+  public static function batchSave() {
     CRM_Core_Page_AJAX::validateAjaxRequestMethod();
     // save the entered information in 'data' column
     $batchId = CRM_Utils_Type::escape($_POST['batch_id'], 'Positive');


### PR DESCRIPTION
Overview
----------------------------------------
In this PR, we backport this fix https://github.com/civicrm/civicrm-core/pull/25029  to our old version of CiviCRM

Included in CiviCRM 5.57.0