### PR TITLE
CIVIMM-261: Support Automatic Email Filing For Case Type Categories Other Than Cases

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -946,7 +946,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
 
     // CRM-5916: strip [case #…] before saving the activity (if present in subject)
-    $activityParams['subject'] = preg_replace('/\[case #([0-9a-h]{7})\] /', '', $activityParams['subject']);
+    $activityParams['subject'] = preg_replace('/\[.*#([0-9a-h]{7})\] /', '', $activityParams['subject']);
 
     // add the attachments to activity params here
     if ($attachments) {

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -77,11 +77,11 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
       $matches = [];
       if (!isset($params['case_id'])) {
         $subjectToMatch = $activity->subject ?? '';
-        if (preg_match('/\[case #([0-9a-h]{7})\]/', $subjectToMatch, $matches)) {
+        if (preg_match('/\[.*#([0-9a-h]{7})\]/', $subjectToMatch, $matches)) {
           $key = CRM_Core_DAO::escapeString(CIVICRM_SITE_KEY);
           $query = "SELECT id FROM civicrm_case WHERE SUBSTR(SHA1(CONCAT('$key', id)), 1, 7) = %1";
         }
-        elseif (preg_match('/\[case #(\d+)\]/', $subjectToMatch, $matches)) {
+        elseif (preg_match('/\[.*#(\d+)\]/', $subjectToMatch, $matches)) {
           $query = "SELECT id FROM civicrm_case WHERE id = %1";
         }
       }

--- a/CRM/Case/Form/Task/Email.php
+++ b/CRM/Case/Form/Task/Email.php
@@ -66,7 +66,7 @@ class CRM_Case_Form_Task_Email extends CRM_Case_Form_Task {
     // CRM-5916: prepend case id hash to CiviCase-originating emails’ subjects
     if ($this->getCaseID()) {
       $hash = substr(sha1(CIVICRM_SITE_KEY . $this->getCaseID()), 0, 7);
-      $subject = "[case #$hash] $subject";
+      $subject = "[#$hash] $subject";
     }
     return $subject;
   }

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -856,7 +856,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     }
 
     // CRM-5916: strip [case #…] before saving the activity (if present in subject)
-    $activityParams['subject'] = preg_replace('/\[case #([0-9a-h]{7})\] /', '', $activityParams['subject']);
+    $activityParams['subject'] = preg_replace('/\[.*#([0-9a-h]{7})\] /', '', $activityParams['subject']);
 
     // add the attachments to activity params here
     if ($attachments) {


### PR DESCRIPTION
Overview
----------------------------------------
This pr adds the support for automatic email filing for cases that belong to any case type category other than 'cases'. Currently it only works for cases case type category.

Technical Details
----------------------------------------
CiviCRM automatically adds a case hash to a case email when it is sent from CiviCRM. This allows any replied emails to be automatically filed on the case (and not just matched to the sender's email address).

In order for emails to be filed on a case CiviCRM needs the following in the subject line:

[case #{civicrm.case_hash}] or [case #{civicrm_case.id}]

The word “case” is required in the token

But for case type categories which are not “cases” the word “case” gets changed (by our customisations) to replace this word with the name of the case type category or instance when an email is sent by CiviCRM for example the above same subject for an award application becomes 

[application #{civicrm.case_hash}] or [application #{civicrm_case.id}]

Hence civicrm does not correctly attaches the replies to cases