### PR TITLE
CIVIMM-240: Fix Disabling Of Inherited Memberships When Relationships Are Being Disabled

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1442,8 +1442,9 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     foreach ($values as $cid => $details) {
       $relatedContacts = array_keys(CRM_Utils_Array::value('relatedContacts', $details, []));
       $mainRelatedContactId = reset($relatedContacts);
+      $relatedMemberships = $relationshipProcessor->getRelationshipMembershipsForContact((int) $cid, $params['membership_type_ids'] ?? []);
 
-      foreach ($relationshipProcessor->getRelationshipMembershipsForContact((int) $cid) as $membershipId => $membershipValues) {
+      foreach ($relatedMemberships as $membershipId => $membershipValues) {
         $membershipInherittedFromContactID = NULL;
         if (!empty($membershipValues['owner_membership_id'])) {
           // @todo - $membership already has this now.
@@ -2229,19 +2230,38 @@ SELECT count(*)
 
     // Check if relationship can be used for related memberships
     $membershipTypes = MembershipType::get(FALSE)
-      ->addSelect('relationship_type_id')
-      ->addGroupBy('relationship_type_id')
+      ->addSelect('relationship_type_id', 'id')
       ->addWhere('relationship_type_id', 'IS NOT EMPTY')
       ->execute();
+
+    $otherValidRelationshipTypes = Relationship::get(FALSE)
+      ->addSelect('relationship_type_id')
+      ->setWhere([
+        ['contact_id_a', '=', $relationship->contact_id_a],
+        ['contact_id_b', '=', $relationship->contact_id_b],
+        ['OR', [['start_date', '<=', 'now'], ['start_date', 'IS EMPTY']]],
+        ['OR', [['end_date', '>=', 'now'], ['end_date', 'IS EMPTY']]],
+        ['is_active', '=', TRUE],
+        ['relationship_type_id', '!=', $relationship->relationship_type_id],
+      ])
+      ->execute()
+      ->getArrayCopy();
+
+    $otherValidRelationshipTypeIds = !empty($otherValidRelationshipTypes) ? array_column($otherValidRelationshipTypes, 'relationship_type_id') : [];
+    $params['membership_type_ids'] = [];
+
     foreach ($membershipTypes as $membershipType) {
       // We have to loop through them because relationship_type_id is an array and we can't filter by a single
       // relationship id using API.
-      if (in_array($relationship->relationship_type_id, $membershipType['relationship_type_id'])) {
-        $relationshipIsUsedForRelatedMemberships = TRUE;
+      if (in_array($relationship->relationship_type_id, $membershipType['relationship_type_id'])
+        && empty(array_intersect($membershipType['relationship_type_id'], $otherValidRelationshipTypeIds))) {
+        $relatedMembershipsNeedsToBeUpdated = TRUE;
+        $params['membership_type_ids'][] = $membershipType['id'];
       }
     }
-    if (empty($relationshipIsUsedForRelatedMemberships)) {
-      // This relationship is not configured for any related membership types
+    if (empty($relatedMembershipsNeedsToBeUpdated)) {
+      // This relationship is not configured for any related membership types or there exists other valid relationships
+      // for related memberships.
       return;
     }
     // Call relatedMemberships to delete/add the memberships of related contacts.

--- a/CRM/Member/Utils/RelationshipProcessor.php
+++ b/CRM/Member/Utils/RelationshipProcessor.php
@@ -54,12 +54,15 @@ class CRM_Member_Utils_RelationshipProcessor {
    *
    * @param int $contactID
    *
+   * @param array $membershipTypeIds
+   *
    * @return array
    */
-  public function getRelationshipMembershipsForContact(int $contactID):array {
+  public function getRelationshipMembershipsForContact(int $contactID, array $membershipTypeIds = []):array {
     $memberships = [];
     foreach ($this->memberships as $id => $membership) {
-      if ((int) $membership['contact_id'] === $contactID) {
+      if ((int) $membership['contact_id'] === $contactID &&
+        (in_array($membership['membership_type_id'], $membershipTypeIds) || empty($membershipTypeIds))) {
         $memberships[$id] = $membership;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Currently there are below mentioned issues related to relationships and inherited memberships

- When a membership type has multiple relationships enabled to inherit, and an individual has multiple relationships with the organisation that are enabled for inheriting and when user edits one of the relationships, and add an end date in the past relationship gets inactive which is correct, but the inherited membership gets removed which is incorrect as there is still one qualifying active relationship.
- Then when user edits the second relationship and adds an end date in the past and save, relationship gets inactive which is correct, but the inherited membership will be added back which is incorrect as at this point there is no qualifying active relationship.
- When there are two membership types that has one relationships each enabled to inherit and user creates an organisation with both these memberships and create both of the relationships between an individual and the organisation then inherited memberships are created for individual but when user edits one of the relationships, and add an end date in the past the relationship gets inactive which is correct, but both the memberships gets removed from individual whereas only one should get removed.

This pr solves this issue as per below rules

- When a relationship is ended and if that relationship type provides any memberships by relationship and is the only relationship type which is proving that membership by relationship then the relevant membership (and only that membership) by relationship is ended.
- If however there are other relationship types that provide that membership by relationship those membership should not end plus if there are other memberships provided by other relationship types they should not be affected as well.