### PR TITLE
CIWEMSPRT-45: Fix Duplicate Financial Item For Membership Payments

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -268,6 +268,17 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   public function preProcess() {
     parent::preProcess();
     $this->_ccid = $this->get('ccid');
+    if ($this->_ccid) {
+      try {
+        $this->_membershipId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment',
+          $this->_ccid,
+          'membership_id',
+          'contribution_id'
+        );
+      }
+      catch (Throwable $e) {
+      }
+    }
 
     $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
@@ -1372,7 +1383,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param array $membershipTypeIDs
    *
    * @param bool $isPaidMembership
-   * @param array $membershipID
+   * @param int $membershipID
    *
    * @param int $financialTypeID
    *   Line items for payment options chosen on the form.
@@ -2892,7 +2903,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // Load all line items & process all in membership. Don't do in contribution.
     // Relevant tests in api_v3_ContributionPageTest.
     $memParams['line_item'] = $lineItems;
-    // @todo stop passing $ids (membership and userId may be set by this point)
+    $ids['membership'] = !empty($ids['membership']) ? $ids['membership'] : $membershipID;
     $membership = CRM_Member_BAO_Membership::create($memParams, $ids);
 
     // not sure why this statement is here, seems quite odd :( - Lobo: 12/26/2010


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes an issue that results in duplicate financial items creation. To reproduce the issue create a membership for a contact with pending payment status and check that one financial item gets created then pay for the contribution through a contribution page now check the financial item table there will be an exact duplicate of financial item that was created previously.

Technical Details
----------------------------------------
The issue here is that in contribution confirm page we check if there is any active membership for the user and if there isn't one we treat it as new membership creation whereas there exists one more scenario when user is paying for a pending contribution and in this scenario we should not treat it as new membership creation.