### PR TITLE
CIWEMSPRT-46: Remove duplicate financial transaction record

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -412,21 +412,38 @@ class CRM_Contribute_BAO_FinancialProcessor {
     }
     $params['is_payment'] = FALSE;
 
-    $trxnId = civicrm_api3('FinancialTrxn', 'get', [
-      'contribution_id' => $params['contribution_id'] ?? NULL,
-      'to_financial_account_id' => $params['to_financial_account_id'] ?? NULL,
-      'total_amount' => $params['total_amount'] ?? NULL,
-      'fee_amount' => $params['fee_amount'] ?? NULL,
-      'net_amount' => $params['net_amount'] ?? NULL,
-      'currency' => $params['currency'] ?? NULL,
-      'status_id' => $params['status_id'] ?? NULL,
-      'is_payment' => FALSE,
-      'sequential' => 1,
-      'options' => ['limit' => 1, 'sort' => 'id desc'],
-    ])['id'] ?? NULL;
+    if ($params['contribution_id']) {
+      $trxn = \Civi\Api4\EntityFinancialTrxn::get(FALSE)
+        ->addSelect('financial_trxn_id')
+        ->addWhere('entity_id', '=', $params['contribution_id'])
+        ->addWhere('entity_table', '=', 'civicrm_contribution');
 
-    if ($trxnId === NULL) {
-      $trxn = CRM_Core_BAO_FinancialTrxn::create($params);
+      if ($params['to_financial_account_id']) {
+        $trxn->addWhere('financial_trxn_id.to_financial_account_id', '=', $params['to_financial_account_id']);
+      }
+      if ($params['from_financial_account_id']) {
+        $trxn->addWhere('financial_trxn_id.from_financial_account_id', '=', $params['from_financial_account_id']);
+      }
+      if ($params['total_amount']) {
+        $trxn->addWhere('financial_trxn_id.total_amount', '=', $params['total_amount']);
+      }
+      if ($params['currency']) {
+        $trxn->addWhere('financial_trxn_id.currency', '=', $params['currency']);
+      }
+
+      $trxn = $trxn->addWhere('financial_trxn_id.status_id', '=', $params['status_id'])
+        ->addWhere('financial_trxn_id.is_payment', '=', 0)
+        ->execute()
+        ->first();
+
+      $trxnId = $trxn['financial_trxn_id'] ?? NULL;
+      if ($trxnId === NULL) {
+        $trxn   = CRM_Core_BAO_FinancialTrxn::create($params);
+        $trxnId = $trxn->id;
+      }
+    }
+    else {
+      $trxn   = CRM_Core_BAO_FinancialTrxn::create($params);
       $trxnId = $trxn->id;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
When a contribution is created and paid through back office(contact summary page) or a new contribution is created and paid immediately through  a contribution page it results in one pending transaction and one completed transaction which seems to be correct 

<img width="1792" alt="Screenshot_2025-01-23_at_1 56 34_PM" src="https://github.com/user-attachments/assets/f915a198-4def-4b48-a574-a45083e1b72e" />

but if a contribution is created in a pending state with pay later option and then later on when user pays for that contribution in full using a contribution page then for this contribution we get two pending transactions and one completed transation

<img width="1792" alt="Screenshot_2025-01-23_at_1 57 22_PM" src="https://github.com/user-attachments/assets/15f26eaf-7ee4-4473-895d-c8ba6ba3b132" />

The first pending one was created at the time of contribution creation and second pending one was created when user paid for the contribution and these two seems to be duplicate of each other

Steps to reproduce
- Login as an admin
- Create a contribution for any contact in pending state and pay later option
- Login as that contact and try to pay for that contribution using any contribution page
- Check the transaction records for the contribution


Before this there has been two prs to fix this issue https://github.com/compucorp/civicrm-core/pull/149 and https://github.com/compucorp/civicrm-core/pull/150 although these prs fixed the issue to an extent but webform contribution was still not working as expected and there was no pending transaction was getting created due to the fact the parameters we get in this changed function were slightly different so this PR is a continuation of the previous prs and in this we cover all different user flow including 

- Direct webform payment,
- Direct admin paid contribution creation,
- Direct payment through contribution page,
- Pending Contribution creation and then completing it either through contribution page or admin payment recording

