### PR TITLE
CIWEMSPRT-45: Fix duplicate financial item for membership payments

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2757,6 +2757,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $memParams['contribution_recur_id'] = $contributionRecurID;
         }
 
+        $ids['membership'] = $currentMembership['id'];
         $membership = CRM_Member_BAO_Membership::create($memParams);
         return [$membership, $renewalMode, $dates];
       }


### PR DESCRIPTION
Overview
----------------------------------------
This pr is a continuity of https://github.com/compucorp/civicrm-core/pull/151 as in that pr we missed [this](https://github.com/compucorp/civicrm-core/blob/4dd4b94932c1d7c0450b775872c06cae0e96a953/CRM/Contribute/Form/Contribution/Confirm.php#L2761) spot in code, this happens when a logged in contact is paying for his pending membership through a contribution page.
