### PR TITLE
CIWEMSPRT-45: Fix Duplicate Financial Items For Membership Payment

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2758,7 +2758,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
 
         $ids['membership'] = $currentMembership['id'];
-        $membership = CRM_Member_BAO_Membership::create($memParams);
+        $membership = CRM_Member_BAO_Membership::create($memParams, $ids);
         return [$membership, $renewalMode, $dates];
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This pr is a continuity of https://github.com/compucorp/civicrm-core/pull/151 as in that pr we missed to add $ids param for CRM_Member_BAO_Membership::create method.
