### PR TITLE
CIWEMSPRT-45: Fix duplicate membership transactions

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -436,16 +436,13 @@ class CRM_Contribute_BAO_FinancialProcessor {
         ->execute()
         ->first();
 
-      $trxnId = $trxn['financial_trxn_id'] ?? NULL;
-      if ($trxnId === NULL) {
-        $trxn   = CRM_Core_BAO_FinancialTrxn::create($params);
-        $trxnId = $trxn->id;
+      if (!empty($trxn['financial_trxn_id'])) {
+        return NULL;
       }
     }
-    else {
-      $trxn   = CRM_Core_BAO_FinancialTrxn::create($params);
-      $trxnId = $trxn->id;
-    }
+
+    $trxn   = CRM_Core_BAO_FinancialTrxn::create($params);
+    $trxnId = $trxn->id;
 
     if ($contributionStatus != 'Completed') {
       $trxnParams['from_financial_account_id'] = $arAccountId;


### PR DESCRIPTION
Overview
----------------------------------------
In [this](https://github.com/compucorp/civicrm-core/pull/150) PR we managed to detect and restrict the duplicate financial transactions but still the transaction id was being returned in case the financial transaction already existed this caused an issue that later on in the code the financial items were getting duplicated with that returned financial transaction id. So this PR fixes the issue and returns NULL when there is already a financial transaction existing.