### PR TITLE
CIWEMSPRT-48: Fix Fees Financial Record Creation

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -108,6 +108,12 @@ class CRM_Financial_BAO_Payment {
         'trxnParams' => [
           'trxn_date' => $paymentTrxnParams['trxn_date'],
           'currency' => $paymentTrxnParams['currency'],
+          'trxn_id' => isset($paymentTrxnParams['trxn_id']) ? $paymentTrxnParams['trxn_id'] : NULL,
+          'payment_instrument_id' => isset($paymentTrxnParams['payment_instrument_id']) ? $paymentTrxnParams['payment_instrument_id'] : NULL,
+          'check_number' => isset($paymentTrxnParams['check_number']) ? $paymentTrxnParams['check_number'] : NULL,
+          'pan_truncation' => isset($paymentTrxnParams['pan_truncation']) ? $paymentTrxnParams['pan_truncation'] : NULL,
+          'card_type_id' => isset($paymentTrxnParams['card_type_id']) ? $paymentTrxnParams['card_type_id'] : NULL,
+          'payment_processor_id' => isset($paymentTrxnParams['payment_processor_id']) ? $paymentTrxnParams['payment_processor_id'] : NULL,
         ],
       ];
 
@@ -592,12 +598,12 @@ class CRM_Financial_BAO_Payment {
       $payableItems[$payableItemIndex] = $item;
     }
 
-    // Custom patch to correct roundoff errors 
+    // Custom patch to correct roundoff errors
     if (empty($lineItemOverrides) && !empty($ratio) && isset($payableItems[$payableItemIndex])) {
       $totalTaxAllocation = 0;
       $totalAllocation = 0;
       $lastNonTaxKey = $payableItemIndex;
-    
+
       foreach ($payableItems as $key => $item) {
         if ($item['financial_item.financial_account_id.is_tax']) {
           $totalTaxAllocation += $item['allocation'];
@@ -607,10 +613,10 @@ class CRM_Financial_BAO_Payment {
           $lastNonTaxKey = $key;
         }
       }
-      
+
       $total = $totalTaxAllocation + $totalAllocation;
       $leftPayment = $params['total_amount'] - $total;
-    
+
       if ($lastNonTaxKey !== NULL) {
         $payableItems[$lastNonTaxKey]['allocation'] += $leftPayment;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Currently when we make a credit card payment for a pending contribution through **submit credit card payment** option in contact summary page using any payment processor the financial record that gets created for the fee does not have all the details specifically the record in db is missing

- trxn_id
- payment_instrument_id
- check_number
- pan_truncation
- card_type_id
- payment_processor_id

This PR fixes this issue and adds the missing info

## Technical Details
While creating financial transaction for fees we were not sending the full details to the function that was responsible for creating the financial transaction, this PR passes the missing info.

This PR is partially included in https://github.com/civicrm/civicrm-core/pull/26804 but it looks different from core PR because the core PR was created some time back but it did not get merged and our code already had some part of the core PR that was merged here https://github.com/compucorp/civicrm-core/pull/111