### PR TITLE
DTAB-109: Add Order V4 API

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
+use Civi\Api4\Generic\Result;
 use Civi\Api4\LineItem;
 use Civi\Api4\PriceField;
 use Civi\Api4\PriceFieldValue;
@@ -79,6 +81,8 @@ class CRM_Financial_BAO_Order {
   protected $overridableFinancialTypeID;
 
   private $isExcludeExpiredFields = FALSE;
+
+  private array $contributionValues;
 
   /**
    * @param bool $isExcludeExpiredFields
@@ -1149,10 +1153,24 @@ class CRM_Financial_BAO_Order {
       }
     }
     if (!isset($lineItem['financial_type_id'])) {
-      $lineItem['financial_type_id'] = $this->getDefaultFinancialTypeID();
+      if (!empty($lineItem['price_field_value_id'])
+        && $lineItem['price_field_value_id'] !== $this->getDefaultPriceFieldValueID()) {
+        // We have a price field value ID and this value is not the default one used for
+        // 'generic' line items, so we can load the financial type ID from it.
+        $lineItem['financial_type_id'] = $this->getPriceFieldValueSpec($lineItem['price_field_value_id'])['financial_type_id'];
+      }
+      else {
+        $lineItem['financial_type_id'] = $this->getDefaultFinancialTypeID();
+      }
     }
-    if (!is_numeric($lineItem['financial_type_id'])) {
-      $lineItem['financial_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', $lineItem['financial_type_id']);
+    if (!isset($lineItem['membership_type_id']) && !empty($lineItem['price_field_value_id'])) {
+      $lineItem['membership_type_id'] = $this->getPriceFieldValueSpec($lineItem['price_field_value_id'])['membership_type_id'];
+    }
+    if (!isset($lineItem['membership_num_terms']) && !empty($lineItem['price_field_value_id'])) {
+      $lineItem['membership_num_terms'] = $this->getPriceFieldValueSpec($lineItem['price_field_value_id'])['membership_num_terms'];
+    }
+    if (!empty($lineItem['membership_type_id']) && !isset($lineItem['membership_num_terms'])) {
+      $lineItem['membership_num_terms'] = 1;
     }
     if ($this->getOverrideTotalAmount()) {
       $this->addTotalsToLineBasedOnOverrideTotal((int) $lineItem['financial_type_id'], $lineItem);
@@ -1432,6 +1450,78 @@ class CRM_Financial_BAO_Order {
       }
     }
     return $lineItemTitle ?? '';
+  }
+
+  /**
+   * @param array $contributionValues
+   *
+   * @return \Civi\Api4\Generic\Result
+   *
+   * @internal Access through apiv4 Order api only. Signature subject to change.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function save(array $contributionValues): Result {
+    $this->contributionValues = $contributionValues;
+    foreach ($this->getLineItems() as $index => $lineItem) {
+      // Save entities first, so we can get the Entity ID.
+      if ($lineItem['entity_table'] !== 'civicrm_contribution') {
+        $this->setLineItemValue('entity_id', $this->saveLineItemEntity($lineItem), $index);
+      }
+    }
+    $contributionValues['total_amount'] = $this->getTotalAmount();
+    $contributionValues['tax_amount'] = $this->getTotalTaxAmount();
+    $contributionValues['amount_level'] = $this->getAmountLevel();
+    $contributionValues['contribution_status_id:name'] = 'Pending';
+    $contributionValues['line_item'] = [$this->getLineItems()];
+    return Contribution::create()
+      ->setValues($contributionValues)->execute();
+  }
+
+  /**
+   * Save the entity related to a given line item.
+   *
+   * @param array $lineItem
+   *
+   * @return int
+   * @throws \CRM_Core_Exception
+   */
+  private function saveLineItemEntity(array $lineItem): int {
+    $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForTable($lineItem['entity_table']);
+    $entityValues = empty($lineItem['entity_id']) ? [] : ['id' => $lineItem['entity_id']];
+    foreach ($lineItem as $fieldName => $fieldValue) {
+      if (str_starts_with($fieldName, 'entity_id.')) {
+        $entityValues[substr($fieldName, 10)] = $fieldValue;
+      }
+      if ($fieldName === 'membership_type_id' && $entity === 'Membership') {
+        $entityValues['membership_type_id'] = $fieldValue;
+      }
+    }
+    if (empty($entityValues['id'])) {
+      // Not an update, include any relevant values (e.g. contact_id) from the contribution
+      // entity values if not present already in EntityFields.
+      $fields = (array) civicrm_api4($entity, 'getfields')->indexBy('name');
+      $carryOverFields = array_intersect_key($this->contributionValues, $fields);
+      $entityValues += $carryOverFields;
+      if ($entity === 'Membership' && empty($entityValues['status_id'])) {
+        if (empty($entityValues['join_date'])) {
+          $entityValues['join_date'] = $this->contributionValues['receive_date'];
+        }
+        $entityValues['status_id'] = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate(
+          $entityValues['start_date'] ?? NULL,
+          $entityValues['end_date'] ?? NULL,
+          $entityValues['join_date'] ?? NULL,
+          $this->contributionValues['receive_date'],
+          TRUE,
+          $entityValues['membership_type_id']
+        )['id'];
+      }
+    }
+    if (array_keys($entityValues) === ['id']) {
+      // Nothing to save.
+      return $entityValues['id'];
+    }
+    return civicrm_api4($entity, 'save', ['records' => [$entityValues]])->first()['id'];
   }
 
 }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -382,10 +382,7 @@ WHERE li.contribution_id = %1";
       return;
     }
 
-    foreach ($lineItems as $priceSetId => &$values) {
-      if (!$priceSetId) {
-        continue;
-      }
+    foreach ($lineItems as &$values) {
 
       foreach ($values as &$line) {
         if (empty($line['entity_table'])) {

--- a/Civi/Api4/Action/Order/Create.php
+++ b/Civi/Api4/Action/Order/Create.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Order;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ *
+ * @method $this setContributionValues(array $contributionValues) Set contribution values.
+ */
+class Create extends AbstractAction {
+
+  /**
+   * Values corresponding to the contribution entity.
+   *
+   * @var array
+   */
+  protected $contributionValues;
+
+  protected $lineItems;
+
+  /**
+   * @param array $lineItem
+   *
+   * @return $this
+   */
+  public function addLineItem(array $lineItem): Create {
+    $this->lineItems[] = $lineItem;
+    return $this;
+  }
+
+  /**
+   * @param array $lineItems
+   *
+   * @return $this
+   */
+  public function setLineItems(array $lineItems): Create {
+    $this->lineItems = $lineItems;
+    return $this;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  protected function getContributionValues(): array {
+    $values = $this->contributionValues;
+    $financialType = $values['financial_type_id:name'] ?? $values['financial_type_id.name'] ?? NULL;
+    if (empty($values['financial_type_id']) && $financialType) {
+      $values['financial_type_id'] = (int) \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', $financialType);
+      if (!$values['financial_type_id']) {
+        throw new \CRM_Core_Exception(ts('Invalid financial type %1', [1 => $financialType]));
+      }
+    }
+    return $values;
+  }
+
+  /**
+   * Run the api Action.
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function _run(Result $result): void {
+    $order = new \CRM_Financial_BAO_Order();
+    $order->setDefaultFinancialTypeID($this->getContributionValues()['financial_type_id'] ?? NULL);
+
+    foreach ($this->lineItems as $index => $lineItem) {
+      $order->setLineItem($lineItem, $index);
+    }
+    $result[] = $order->save($this->getContributionValues())->first();
+  }
+
+}

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -99,6 +99,9 @@ function civicrm_api3_order_create(array $params): array {
           $lineItem['membership_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'membership_type_id', $lineItems['params']['membership_type_id']);
         }
         $lineIndex = $index . '+' . $innerIndex;
+        if (!empty($lineItem['financial_type_id']) && !is_numeric($lineItem['financial_type_id'])) {
+          $lineItem['financial_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', $lineItem['financial_type_id']);
+        }
         $order->setLineItem($lineItem, $lineIndex);
         $order->addLineItemToEntityParameters($lineIndex, $index);
       }


### PR DESCRIPTION
## Overview
----------------------------------------
This implements the basic outline of the apiv4 Order create api, providing parity with apiv3 but a different signature.

## Technical Details
This new api can be used as 
```
\Civi\Api4\Order::create()
->setContributionValues($contributionValuesArray)
->addLineItem($lineItemValueArray)
->execute()
```
