### PR TITLE
CIVIMM-332: Fix saving of tags during case activity creation

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -551,8 +551,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         CRM_Core_BAO_EntityTag::create($tagParams, 'civicrm_activity', $vval['actId']);
 
         //save free tags
-        if (isset($params['taglist']) && !empty($params['taglist'])) {
-          CRM_Core_Form_Tag::postProcess($params['taglist'], $vval['actId'], 'civicrm_activity', $this);
+        if (isset($params['activity_taglist']) && !empty($params['activity_taglist'])) {
+          CRM_Core_Form_Tag::postProcess($params['activity_taglist'], $vval['actId'], 'civicrm_activity', $this);
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the saving of free tags during activity creation in a case.

Before
----------------------------------------
If there is a free tag set for activities and user selects any value for this tag set during case activity creation the value for this free tag set was not saving correctly.
![screen_recording_before](https://github.com/user-attachments/assets/de3e25d6-dd7d-4763-9d49-073e870b4307)

After
----------------------------------------
The value for free tag set is saved correctly.
![screen_recording_after](https://github.com/user-attachments/assets/8fb41718-1353-474a-9889-6653387208f5)
