### PR TITLE
CIVIMM-337: Upgrader - Tighten bolts to prevent bad/premature reconci…

### DIFF
--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -115,6 +115,8 @@ class CRM_Upgrade_DispatchPolicy {
       'hook_civicrm_config' => 'run',
       // cleanupPermissions() in some UF's can be destructive. Running prematurely could be actively harmful.
       'hook_civicrm_permission' => 'fail',
+      // ManagedEntities::reconcile() can remove data. Running prematurely would be actively harmful.
+      'hook_civicrm_managed' => 'fail',
       'hook_civicrm_crypto' => 'drop',
       '/^hook_civicrm_(pre|post)$/' => 'drop',
       '/^hook_civicrm_/' => $strict ? 'warn-drop' : 'drop',


### PR DESCRIPTION
## Overview

To improve safety during the upgrade process, this change ensures that if any extension or module attempts to invoke the `hook_civicrm_managed`, the call will **fail**.

The `hook_civicrm_managed` is used to reconcile managed entities, and calling it prematurely, before the upgrade is complete, can result in unintended data removal or inconsistencies. By explicitly blocking it during the upgrade phase, we prevent these potential issues.

Related core PR: [civicrm-core#33124](https://github.com/civicrm/civicrm-core/pull/33124)

Issue https://lab.civicrm.org/dev/core/-/issues/5969