### PR TITLE
COMCL-823: Fix Handling Of Future Memberships

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4235,6 +4235,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $changeDate, NULL, $membershipParams['num_terms']
         );
         $dates['join_date'] = $currentMembership['join_date'];
+        // we should only consider the calculated dates if they are greater then membership dates
+        $dates['start_date'] = strtotime($membership['start_date']) > strtotime(CRM_Utils_Date::customFormat($dates['start_date'], '%Y-%m-%d')) ?
+          $membership['start_date'] : $dates['start_date'];
+        $dates['end_date'] = strtotime($membership['end_date']) > strtotime(CRM_Utils_Date::customFormat($dates['end_date'], '%Y-%m-%d')) ?
+          $membership['end_date'] : $dates['end_date'];
       }
       if ('Pending' === CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membership['status_id'])) {
         $membershipParams['skipStatusCal'] = '';


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the status calculation of memberships when a contribution is marked as completed. Consider a below membership status rule
<img width="1776" height="28" alt="Screenshot 2025-07-17 at 12 35 00 PM" src="https://github.com/user-attachments/assets/eb195e2e-4be7-4903-9f92-704d510e0a2f" />
Now if there is a fixed period type paid membership with start and join date in future and the above shown status with a pending payment and if user submits the payment which completes the contribution the membership gets the status of **current** whereas it should stay in the **future start**  as the future start status rule still matches the dates of membership. This is due to the fact that [here](https://github.com/civicrm/civicrm-core/blob/35d1dca6a3ca278116e694841dd19540143e7508/Civi/Membership/OrderCompleteSubscriber.php#L141)  when we calculate the status for membership upon contribution completion we use the dates which we get from [this](https://github.com/civicrm/civicrm-core/blob/35d1dca6a3ca278116e694841dd19540143e7508/Civi/Membership/OrderCompleteSubscriber.php#L131) renewal dates calculator function which does not accounts for future start date memberships and calculates the dates based on the date of contribution completion and gives the dates of current year even if the membership was for next year.

This PR fixes the issue by only using the calculated renewal dates if they are greater then the membership start and end dates.
