### PR TITLE
COS-268: Make dashboard and dashboard contact entities searchable

### DIFF
--- a/Civi/Api4/Dashboard.php
+++ b/Civi/Api4/Dashboard.php
@@ -20,7 +20,6 @@ namespace Civi\Api4;
  * Displaying an item to a user is done with the `DashboardContact` entity.
  *
  * @see \Civi\Api4\DashboardContact
- * @searchable none
  * @since 5.25
  * @package Civi\Api4
  */

--- a/Civi/Api4/DashboardContact.php
+++ b/Civi/Api4/DashboardContact.php
@@ -17,7 +17,6 @@ namespace Civi\Api4;
  *
  * @searchable bridge
  * @see \Civi\Api4\Dashboard
- * @searchable none
  * @since 5.25
  * @package Civi\Api4
  */


### PR DESCRIPTION
Overview
----------------------------------------
This PR makes dashboard and dashboard contact entities searchable in search kit reports as it could be useful for configuring the dashboards for back office users.
