### PR TITLE
TCOSMM-11: Fix Relationship Custom Field Bug In Search Kit

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -624,13 +624,14 @@ class Api4SelectQuery extends Api4Query {
     $this->openJoin['bridgeKey'] = $joinRef->getReferenceKey();
     $this->openJoin['bridgeCondition'] = array_intersect_key($linkConditions, [1 => 1]);
 
+    // Info needed for joining custom fields extending the bridge entity
+    $this->explicitJoins[$alias]['bridge_table_alias'] = $bridgeAlias;
+
     $outerConditions = [];
     foreach (array_filter($joinTree) as $clause) {
       $outerConditions[] = $this->treeWalkClauses($clause, 'ON');
     }
 
-    // Info needed for joining custom fields extending the bridge entity
-    $this->explicitJoins[$alias]['bridge_table_alias'] = $bridgeAlias;
     // Invert the join so all nested joins will link to the bridge entity
     $this->openJoin['table'] = $bridgeTable;
     $this->openJoin['alias'] = $bridgeAlias;
@@ -917,7 +918,7 @@ class Api4SelectQuery extends Api4Query {
    */
   private function addJoin(string $side, string $tableName, string $tableAlias, string $baseTableAlias, array $conditions): void {
     // If this join is based off the current open join, incorporate it
-    if ($baseTableAlias === ($this->openJoin['alias'] ?? NULL)) {
+    if ($baseTableAlias === ($this->openJoin['alias'] ?? NULL) || $baseTableAlias === ($this->openJoin['bridgeAlias'] ?? NULL)) {
       $this->openJoin['subjoins'][] = [
         'table' => $tableName,
         'alias' => $tableAlias,

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -113,6 +113,11 @@ class Joinable {
       $baseTableAlias = $openJoin['bridgeAlias'];
       $baseColumn = $openJoin['bridgeKey'];
     }
+    // Custom field on bridge table itself; pass-through the $baseColumn as-is
+    elseif (!empty($openJoin['bridgeKey']) && $baseTableAlias === $openJoin['bridgeAlias']) {
+      $conditions = $openJoin['bridgeCondition'];
+      $baseTableAlias = $openJoin['bridgeAlias'];
+    }
     if ($this->baseColumn && $this->targetColumn) {
       $conditions[] = sprintf(
         '`%s`.`%s` =  `%s`.`%s`',


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a fix for a search kit bug that is described below

When building a search kit query based on the contact entity but joining in related contacts, and where a custom field on a relationship is used within the initial ‘search for’ criteria, the search results in an error.