### PR TITLE
FOSFASPRT-77: Fix to financial account for manual payment creation

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -932,6 +932,9 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
       return CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['payment_processor_id'], NULL, 'civicrm_payment_processor');
     }
     if (!empty($params['payment_instrument_id'])) {
+      return CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($params['payment_instrument_id']);
+    }
+    if (!empty($contribution['payment_instrument_id'])) {
       return CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($contribution['payment_instrument_id']);
     }
     else {


### PR DESCRIPTION
## Overview

This PR fixes the **to account calculation** selection when manually recording a payment for a pending contribution. Currently if we try to record a payment for a pending contribution through back office form(contribution tab on contact summary page) then the to financial account for payment transaction will be the financial account for the payment method that was used while creating the contribution even though if we choose a different payment method while recording the payment.

## Technical details

The issue seems to be coming from [this](https://github.com/civicrm/civicrm-core/blob/c243ec5f12386329626e2caeea8c2112711be6c7/CRM/Contribute/BAO/Contribution.php#L958) function.

The logic in this function is that we first try to get the financial account from payment processor and if we dont find it then [we try to get it from the payment method that was used for creating the contribution not the payment method that was used for recording the payment](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/BAO/Contribution.php#L963). At last we try to get it from the default financial account.

This PR fixes the issue by using payment method that was selected during payment creation not the contribution creation and if payment method is not there in the submitted payment form then we fall back to contribution payment method.
