### PR TITLE
COMCL-1308: Allow order api to bypass the create/get permissions

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1545,7 +1545,7 @@ class CRM_Financial_BAO_Order {
     $contributionValues['amount_level'] = $this->getAmountLevel();
     $contributionValues['contribution_status_id:name'] = 'Pending';
     $contributionValues['line_item'] = [$this->getLineItems()];
-    return Contribution::create()
+    return Contribution::create(FALSE)
       ->setValues($contributionValues)->execute();
   }
 
@@ -1592,7 +1592,10 @@ class CRM_Financial_BAO_Order {
       // Nothing to save.
       return $entityValues['id'];
     }
-    return civicrm_api4($entity, 'save', ['records' => [$entityValues]])->first()['id'];
+    return civicrm_api4($entity, 'save', [
+      'records' => [$entityValues],
+      'checkPermissions' => FALSE,
+    ])->first()['id'];
   }
 
   public function getExistingContributionID(): ?int {


### PR DESCRIPTION
Overview
----------------------------------------
This PR Updated CiviCRM API4 calls to disable permission checking by adding FALSE parameter to improve performance and avoid permission-related issues during order processing.

Detailed analysis of the fixes given by @erawat-compuco here - https://compucorp.atlassian.net/browse/DTAB-297?focusedCommentId=223840

Before
----------------------------------------
API4 calls in the Order BAO were running with default permission checking enabled, which could cause failures or performance issues during contribution and line item processing.

After
----------------------------------------
All API4 calls now explicitly disable permission checking by passing FALSE as the fourth parameter, ensuring consistent behavior regardless of the current user's permissions.

Technical Details
----------------------------------------
- Modified `Contribution::create()` call to pass `FALSE` parameter for permission checking
- Modified `civicrm_api4($entity, 'save')` call to add `FALSE` parameter for permission bypass
- All changes maintain existing functionality while improving reliability in automated processes

Comments
----------------------------------------
This change is particularly important for background processes, webhooks, or administrative operations where permission checking might interfere with legitimate system operations.