### PR TITLE
DB-685: Fix order line item amounts

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -82,7 +82,7 @@ class CRM_Financial_BAO_Order {
 
   private $isExcludeExpiredFields = FALSE;
 
-  private array $contributionValues;
+  private array $contributionValues = [];
 
   /**
    * @param bool $isExcludeExpiredFields
@@ -1187,6 +1187,7 @@ class CRM_Financial_BAO_Order {
       $lineItem['tax_rate'] = $this->getTaxRate($lineItem['financial_type_id']);
       $lineItem['tax_amount'] = ($lineItem['tax_rate'] / 100) * $lineItem['line_total'];
       $lineItem['line_total_inclusive'] = $lineItem['tax_amount'] + $lineItem['line_total'];
+      $this->applyCurrencyRounding($lineItem);
     }
     if (!empty($lineItem['membership_type_id'])) {
       $lineItem['entity_table'] = 'civicrm_membership';
@@ -1525,6 +1526,18 @@ class CRM_Financial_BAO_Order {
       'records' => [$entityValues],
       'checkPermissions' => FALSE,
     ])->first()['id'];
+  }
+
+  /**
+   * Apply currency rounding so that tax + net always equals the inclusive amount.
+   *
+   * @param array $lineItem
+   */
+  private function applyCurrencyRounding(array &$lineItem): void {
+    $precision = CRM_Utils_Money::getCurrencyPrecision($this->contributionValues['currency'] ?? CRM_Core_Config::singleton()->defaultCurrency);
+    $lineItem['line_total_inclusive'] = round((float) ($lineItem['line_total_inclusive'] ?? 0.0), $precision);
+    $lineItem['line_total'] = round((float) ($lineItem['line_total'] ?? 0.0), $precision);
+    $lineItem['tax_amount'] = round($lineItem['line_total_inclusive'] - $lineItem['line_total'], $precision);
   }
 
 }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -46,7 +46,7 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
         $params['unit_price'] = 0;
       }
     }
-    if (isset($params['financial_type_id'], $params['line_total'])) {
+    if (!isset($params['tax_amount']) && isset($params['financial_type_id'], $params['line_total'])) {
       $params['tax_amount'] = self::getTaxAmountForLineItem($params);
     }
 


### PR DESCRIPTION
## Overview
This PR fixes a rounding discrepancy in Civi\Api4\Order when creating taxable line items with 3-decimal unit prices.

For example consider a line item as:

```
qty = 3
unit_price = 2.775
financial type tax rate = 20%
```

the expected inclusive total is 9.99, but the created contribution/line-item data could end up as 10.00 due to rounding drift across calculation and persistence layers.

## Problem Summary
When Order builds line items, it computes:

- line_total (net)
- tax_amount
- line_total_inclusive (gross)

However, there were two issues:

Precision drift during net/tax/inclusive math for 3-decimal inputs. Tax recomputation at line-item persistence time, which could overwrite an already-normalized tax_amount and reintroduce cent-level discrepancies. This caused totals to “jump” by 0.01 in edge cases where fractional values and tax interacted.

## Technical Details
1) Currency-aware normalization in CRM_Financial_BAO_Order
A helper (applyCurrencyRounding) was added and invoked during setLineItem() to ensure line-level monetary values are normalized at currency precision before save.

2) Preserve caller-provided tax in CRM_Price_BAO_LineItem::create()
Line item creation previously recalculated tax whenever financial_type_id + line_total were present. Now, tax is recalculated only if tax_amount is not already set.

Why this matters
Order already prepares normalized values. Recomputing tax later can reintroduce drift from raw float arithmetic. Preserving explicit tax_amount keeps the persisted records aligned with normalized order math.

## Before
Input
```
[
  'qty' => 3,
  'unit_price' => 2.775,
  'financial_type_id' => <20% tax type>,
  'entity_table' => 'civicrm_contribution',
  'price_field_id' => 1,
]
Expected monetary intent
Net: 3 × 2.775 = 8.33

Tax (20%): 1.67

Gross: 10.00
```
Intermediate values could be rounded/recomputed inconsistently. Persistence layer recalculated tax from net. Result could end up with gross represented as 10.00.

## After
Input
```
[
  'qty' => 3,
  'unit_price' => 2.775,
  'financial_type_id' => <20% tax type>,
  'entity_table' => 'civicrm_contribution',
  'price_field_id' => 1,
]
Expected monetary intent
Net: 3 × 2.775 = 8.33

Tax (20%): 1.66

Gross: 9.99
```
Order normalizes values at currency precision. Persistence respects provided tax_amount. Final stored totals remain aligned with 9.99 scenario intent.