### PR TITLE
TCOSMM-16: Fix Relationship APIv4 Record Authorization Issue

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2297,11 +2297,12 @@ SELECT count(*)
     $record = $e->getRecord();
     $userID = $e->getUserID();
     $delegateAction = $e->getActionName() === 'get' ? 'get' : 'update';
+    $relationshipID = $record['relationship_id'] ?? $record['id'] ?? NULL;
 
     // Delegate relationship permissions to contacts a & b
     foreach (['a', 'b'] as $ab) {
-      if (empty($record["contact_id_$ab"]) && !empty($record['id'])) {
-        $record["contact_id_$ab"] = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], "contact_id_$ab");
+      if (empty($record["contact_id_$ab"]) && !empty($relationshipID)) {
+        $record["contact_id_$ab"] = CRM_Core_DAO::getFieldValue(__CLASS__, $relationshipID, "contact_id_$ab");
       }
       if (!empty($record["contact_id_$ab"]) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', $delegateAction, ['id' => $record["contact_id_$ab"]], $userID)) {
         $e->setAuthorized(FALSE);


### PR DESCRIPTION
### Overview
This PR improves APIv4 record authorization for Relationship-backed rows (including RelationshipCache usage in SearchKit) by making relationship-contact lookup deterministic and consistent. Previously, authorization delegated to contact_id_a and contact_id_b, but the lookup source could vary(Relationship or RelationshipCache) depending on incoming payload shape (id vs relationship_id) and conditional loading behavior. That made authorization outcomes harder to reason about and could produce inconsistent action visibility in row-level UI actions. This change ensures authorization always resolves the canonical relationship first, then uses authoritative contact_id_a / contact_id_b for delegated permission checks.

### Problem Statement
SearchKit and other APIv4 consumers can pass different identifiers for relationship-oriented records:

- id (entity id)
- relationship_id (underlying relationship id in cache-like contexts)

When authorization logic only conditionally loaded contact ids, results could differ depending on which fields were pre-populated in the incoming record.

### Technical Details
What changed
In CRM_Contact_BAO_Relationship::self_civi_api4_authorizeRecord(...):
Canonical relationship id resolution uses:

$relationshipID = $record['relationship_id'] ?? $record['id'] ?? NULL;
Consistent contact lookup

## Before
Input payload example for relationship cache context
```
{
  "relationship_id": 12345,
  "id": 99999
}
```
Delegated checks evaluate against wrong data i.e relationship with id 99999.

### After
Input payload example for relationship cache context
```
{
  "relationship_id": 12345,
  "id": 99999
}
```
Delegated checks evaluate against correct data i.e relationship with id 12345.