### PR TITLE
DB-685: Fix Oder Contribution Amounts

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1031,9 +1031,9 @@ class CRM_Financial_BAO_Order {
   public function getTotalTaxAmount() :float {
     $amount = 0.0;
     foreach ($this->getLineItems() as $lineItem) {
-      $amount += $lineItem['tax_amount'] ?? 0.0;
+      $amount += $this->roundMonetaryValue((float) ($lineItem['tax_amount'] ?? 0.0));
     }
-    return $amount;
+    return $this->roundMonetaryValue((float) ($amount));
   }
 
   /**
@@ -1046,9 +1046,19 @@ class CRM_Financial_BAO_Order {
   public function getTotalAmount() :float {
     $amount = 0.0;
     foreach ($this->getLineItems() as $lineItem) {
-      $amount += ($lineItem['line_total'] ?? 0.0) + ($lineItem['tax_amount'] ?? 0.0);
+      $lineTotal = $this->roundMonetaryValue((float) ($lineItem['line_total'] ?? 0.0));
+      $taxAmount = $this->roundMonetaryValue((float) ($lineItem['tax_amount'] ?? 0.0));
+      $amount += $lineTotal + $taxAmount;
     }
-    return $amount;
+    return $this->roundMonetaryValue((float) ($amount));
+  }
+
+  /**
+   * Round a monetary value to storage precision.
+   */
+  private function roundMonetaryValue(float $amount): float {
+    $currency = $this->contributionValues['currency'] ?? CRM_Core_Config::singleton()->defaultCurrency;
+    return round($amount, CRM_Utils_Money::getCurrencyPrecision($currency));
   }
 
   /**


### PR DESCRIPTION
## Overview

This PR fixes a rounding inconsistency in Order API v4 contribution creation where, in some edge cases, `contribution.total_amount` could differ by `0.01` from the sum of persisted line item totals.

The issue appears when high-precision unit prices and tax are involved (e.g. `qty=3`, `unit_price=2.775`, `tax=20%`). Depending on the rounding path, one calculation yielded `9.99` while another yielded `10.00`.  
This PR ensures totals are computed in a way that matches stored line-item monetary precision, producing the expected `10.00`.


## Technical Details

Changes were made in:

- `profiles/compuclient/modules/contrib/civicrm/CRM/Financial/BAO/Order.php`

### 1) `getTotalAmount()` now sums rounded line components

- Each line’s `line_total` and `tax_amount` is rounded to monetary precision before summing.
- The final aggregate amount is rounded before return.

This aligns contribution total calculation with line-item storage precision and avoids float carry-over effects.

### 2) `getTotalTaxAmount()` now uses rounded per-line tax values

- Each `tax_amount` is rounded before aggregation.
- Final tax total is rounded before return.

### 3) Added helper for consistent rounding

- Introduced `roundMonetaryValue(float $amount): float`
- Centralizes 2-decimal rounding behavior used by both totals methods.


## Example

Given:

- `qty = 3`
- `unit_price = 2.775`
- `tax_rate = 20%`

Unrounded arithmetic path can produce `9.99`, while line-item monetary-rounded values imply `10.00`.

With this change, contribution totals are derived from the rounded line components, so contribution and line-item totals remain consistent (`10.00`).


## Impact

- ✅ Fixes 0.01 mismatch between contribution totals and line item sums.
- ✅ Improves financial consistency in APIv4 order/contribution creation.
- ✅ Minimal, targeted change within order total aggregation logic.


## Notes

This PR intentionally focuses on alignment with existing line-item monetary precision behavior and avoids broader refactors to pricing/tax computation flows.