### PR TITLE
TCOSMM-15: Fix group fields on mailing screens

### DIFF
--- a/ext/civi_mail/ang/crmMailing/BlockMailing.html
+++ b/ext/civi_mail/ang/crmMailing/BlockMailing.html
@@ -40,7 +40,7 @@ It could perhaps be thinned by 30-60% by making more directives.
     <span ng-controller="EditUnsubGroupCtrl">
       <div crm-ui-field="{name: 'subform.baseGroup', title: ts('Unsubscribe Group')}" ng-if="isUnsubGroupRequired(mailing)">
         <input
-          crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear:true, minimumInputLength: 0}}"
+          crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1, group_type: {LIKE: '%2%'}}}, select: {allowClear:true, minimumInputLength: 0}}"
           crm-ui-id="subform.baseGroup"
           name="baseGroup"
           ng-model="mailing.recipients.groups.base[0]"

--- a/ext/civi_mail/ang/crmMailing/BlockPreview.html
+++ b/ext/civi_mail/ang/crmMailing/BlockPreview.html
@@ -46,7 +46,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     </div>
     <div>
       <input
-        crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear:true, minimumInputLength: 0}}"
+        crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1, group_type: {LIKE: '%2%'}}}, select: {allowClear:true, minimumInputLength: 0}}"
         ng-model="testGroup.gid"
         class="crm-action-menu fa-envelope-o"
         />


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the unsubscribe and Send test email to group fields on mailing screens to only fetch the groups that have been configured for mailing as currently the field fetches the groups regardless of group type.
