### PR TITLE
TCOSMM-5: Respect ACLs For Custom Groups On Advance Search

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -81,7 +81,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
     ];
 
     //check if there are any custom data searchable fields
-    $groupDetails = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Contact', 'is_active' => TRUE]);
+    $groupDetails = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Contact', 'is_active' => TRUE], CRM_Core_Permission::VIEW);
     // if no searchable fields unset panel
     if (empty($groupDetails)) {
       unset($paneNames[ts('Custom Fields')]);

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -603,7 +603,7 @@ class CRM_Contact_Form_Search_Criteria {
    */
   public static function custom(&$form) {
     $form->add('hidden', 'hidden_custom', 1);
-    $groupDetails = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Contact', 'is_active' => TRUE]);
+    $groupDetails = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Contact', 'is_active' => TRUE], CRM_Core_Permission::VIEW);
     $form->assign('groupTree', $groupDetails);
 
     foreach ($groupDetails as $key => $group) {


### PR DESCRIPTION
## Overview
Advanced Contact Search still surfaces restricted custom field sets for users. This PR makes Advanced Search follow the stricter rule:

- If user has `access all custom data`: show all Contact custom groups.
- Otherwise: show only custom groups explicitly granted by CiviCRM ACLs.

## Technical details
Now we use CRM_Core_Permission::VIEW to get all the custom groups which only returns the groups which are permitted to user compared to previously all returned groups

## Files changed
- `profiles/compuclient/modules/contrib/civicrm/CRM/Contact/Form/Search/Advanced.php`
- `profiles/compuclient/modules/contrib/civicrm/CRM/Contact/Form/Search/Criteria.php`

## Example behavior
- **User A** has `access all custom data` → sees all Contact custom field sets in Advanced Search.
- **User B** does not have `access all custom data`, but ACL grants access to only "Membership Details" custom group → sees only that group’s fields.
- **User C** has neither permission nor ACL grant → does not see any