### PR TITLE
FDW-216: Fix Modal Print Button

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -394,7 +394,7 @@
             $(this).dialog('option', 'title', data.title);
           }
           // Update print url
-          $(this).parent().find('a.crm-dialog-titlebar-print').attr('href', $(this).data('civiCrmSnippet')._formatUrl($(this).crmSnippet('option', 'url'), '2'));
+          $(this).parent().find('a.crm-dialog-titlebar-print').attr('href', $(this).data('civiCrmSnippet')._formatUrl($(this).crmSnippet('option', 'url'), '1'));
         });
     }
     $(settings.target).crmSnippet(settings).crmSnippet('refresh');


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a regression issue that caused errors when user clicked on print icon on a contribution view modal or any other modal.

Before
----------------------------------------
[Print Invocie issue in CRM.webm](https://github.com/user-attachments/assets/d5ffcddb-1b13-469f-bd85-3e1aaed5a866)


After
----------------------------------------
![screen_recording_after](https://github.com/user-attachments/assets/d42a5688-c241-49ac-b91c-a846ccc4f49b)
