### PR TITLE
CIVIPLMMSR-568: Fix scheduled_date being nullified after mailing submit

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1098,6 +1098,20 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     // CRM-20892 Unset Modifed Date here so that MySQL can correctly set an updated modfied date.
     unset($params['modified_date']);
 
+    // Prevent scheduled_date from being nullified on updates.
+    // The crmMailingMgr JS service calls Mailing.create for save/preview
+    // operations, passing scheduled_id (from the mailing model) but deleting
+    // scheduled_date (to avoid re-triggering scheduling). When writeRecord
+    // processes the update, the orphaned scheduled_id without scheduled_date
+    // causes the valid scheduled_date to be overwritten with NULL in the DB.
+    if (!empty($id) && !empty($params['scheduled_id'])
+      && array_key_exists('scheduled_date', $params)
+      && (empty($params['scheduled_date']) || $params['scheduled_date'] === 'null')
+    ) {
+      \Civi::log()->warning('Mailing: prevented scheduled_date from being nullified for mailing ' . $id . ', scheduled_id=' . $params['scheduled_id']);
+      unset($params['scheduled_date']);
+    }
+
     $result = static::writeRecord($params);
 
     // CRM-20892 Re find record after saing so we can set the updated modified date in the result.

--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -300,6 +300,7 @@
           }
         });
         delete params.scheduled_date;
+        delete params.scheduled_id;
         delete params.recipients; // the content was merged in
         return qApi('Mailing', 'create', params).then(function (recipResult) {
           // changes rolled back, so we don't care about updating mailing
@@ -333,6 +334,7 @@
             crmMailingCache.put('mailing-' + mailing.id + '-recipient-params', params.recipients);
           }
           delete params.scheduled_date;
+          delete params.scheduled_id;
           delete params.recipients; // the content was merged in
           recipientCount = qApi('Mailing', 'create', params).then(function (recipResult) {
             // changes rolled back, so we don't care about updating mailing
@@ -365,6 +367,7 @@
         // as an *intent* to schedule and creates tertiary records. Saving a draft with a scheduled_date
         // is therefore not allowed. Remove this after fixing Mailing.create's contract.
         delete params.scheduled_date;
+        delete params.scheduled_id;
 
         delete params.jobs;
 
@@ -418,6 +421,7 @@
         // as an *intent* to schedule and creates tertiary records. Saving a draft with a scheduled_date
         // is therefore not allowed. Remove this after fixing Mailing.create's contract.
         delete params.scheduled_date;
+        delete params.scheduled_id;
 
         delete params.jobs;
 


### PR DESCRIPTION
## Summary

Patch for CIVIPLMMSR-568: Fixes scheduled_date being overwritten with NULL after mailing submit. The crmMailingMgr JS service deletes scheduled_date before calling Mailing.create but leaves scheduled_id, causing writeRecord to nullify the DB value. Also adds a backend guard in BAO::add() to prevent scheduled_date from being nullified on updates.

Core PR: https://github.com/civicrm/civicrm-core/pull/35137

## Patch commit

```
CIVIPLMMSR-568: Fix scheduled_date being nullified after mailing submit
PR: https://github.com/civicrm/civicrm-core/pull/35137
```