### PR TITLE
CIWEMB-635: Fix membership form using wrong price set during submission

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -93,7 +93,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   public static function getSelectedMemberships($priceSet, $params) {
     $memTypeSelected = [];
     $priceFieldIDS = self::getPriceFieldIDs($params, $priceSet);
-    if (isset($params['membership_type_id']) && !empty($params['membership_type_id'][1])) {
+    if (isset($params['membership_type_id']) && !empty($params['membership_type_id'][1]) && empty($params['price_set_id'])) {
       $memTypeSelected = [$params['membership_type_id'][1] => $params['membership_type_id'][1]];
     }
     else {


### PR DESCRIPTION
## Summary

Patch for CIWEMB-635: Fixes DB constraint violation when creating membership via non-quick-config price set on the back-office membership form. `getPriceSetID()` falls back to the default quick-config price set instead of the one selected by the user, causing `membership_type_id` to be missing from the INSERT.

Core PR: https://github.com/civicrm/civicrm-core/pull/35144

## Patch commit

```
CIWEMB-635: Fix membership form using wrong price set during submission
PR: https://github.com/civicrm/civicrm-core/pull/35144
```