### PR TITLE
CSTSPRT-297: Send Back 400 Invalid Parameters Response If url_id Is Not Validated Rather Than 500 Error

### DIFF
--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -31,7 +31,10 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
    */
   public function run() {
     $queue_id = CRM_Utils_Request::retrieveValue('qid', 'Integer');
-    $url_id = CRM_Utils_Request::retrieveValue('u', 'Integer', NULL, TRUE);
+    $url_id = CRM_Utils_Request::retrieveValue('u', 'Integer');
+    if (!$url_id) {
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Missing input parameters"));
+    }
     $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track($queue_id, $url_id));
     $query_string = $this->extractPassthroughParameters();
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR backports the changes from https://github.com/civicrm/civicrm-core/pull/33541
