### PR TITLE
CSTSPRT-298: Discard head requests

### DIFF
--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -35,7 +35,8 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
     if (!$url_id) {
       CRM_Utils_System::sendResponse(new GuzzleHttp\Psr7\Response(400, [], ts('Missing input parameters')));
     }
-    $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track($queue_id, $url_id));
+    $isHead = ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'HEAD';
+    $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track($isHead ? NULL : $queue_id, $url_id));
     $query_string = $this->extractPassthroughParameters();
 
     if (strlen($query_string) > 0) {


### PR DESCRIPTION
Overview
----------------------------------------
HEAD requests make up a significant portion of all click-tracking traffic, which are email security scanners and link previewers (e.g. Microsoft SafeLinks) and not real human clicks and should not be counted as url clicks, this PR improves the click through url count by ignoring HEAD requests for click through tracxking.
