### PR TITLE
IESSPRT-298: Fix Failure To Load Membership Custom Data On Initial Load

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -224,7 +224,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     }
 
     $this->assign('customDataType', 'Membership');
-    $this->assign('customDataSubType', $this->_memType);
+    $this->assign('customDataSubType', $this->getMembershipValue('membership_type_id'));
 
     $this->setPageTitle(ts('Membership'));
   }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes an issue that When loading the Update Membership popup screen for a contact of type Individual, the custom fields do not display at the bottom of the edit screen. If you toggle the Membership Type drop down menu at the top of this screen to another membership type and back, then the custom fields DO show.
Seems to be an issue under these conditions:

- Only on initial loading of the Update Membership popup screen.
- When custom group is for a subset of Membership Types (membership subtype)

This was happening due to the fact that the membership type was not assigned correctly in form so this PR fixes the issue by correctly assigning membership type.
