### PR TITLE
CIVIPLMMSR-596: Fix Case Detail Input Type

### DIFF
--- a/schema/Case/Case.entityType.php
+++ b/schema/Case/Case.entityType.php
@@ -119,7 +119,7 @@ return [
     'details' => [
       'title' => ts('Details'),
       'sql_type' => 'text',
-      'input_type' => 'TextArea',
+      'input_type' => 'RichTextEditor',
       'description' => ts('Details populated from Open Case. Only used in the CiviCase extension.'),
       'add' => '1.8',
       'input_attrs' => [


### PR DESCRIPTION
## Overview

The `details` column on `civicrm_case` stores HTML produced by the WYSIWYG editor on the *Open Case* form (`CRM_Case_Form_Case::postProcess` already runs the value through `CRM_Utils_String::purifyHTML` before saving). The schema, however, declared the field as a plain `TextArea`, so consumers that key off field metadata most visibly **SearchKit** treated the value as plain text and rendered it with the markup escaped (e.g. `<p>Hello</p>` shown literally instead of as a paragraph).

## Before

When `civicrm_case.details` was added to a SearchKit display the column showed raw HTML tags rather than the formatted output, because `crmSearchAdmin.fieldToColumn()` only flags a column as `type: 'html'` when the underlying field's `input_type === 'RichTextEditor'`.

## After

`schema/Case/Case.entityType.php` declares `details.input_type = 'RichTextEditor'`. Side-effects:

- New SearchKit columns added against this field automatically default to `type: 'html'`, so `AbstractRunAction` runs the value through `CRM_Utils_String::purifyHTML()` and renders proper markup.
- `Api4 getFields` for `Case` now reports the field's `html.type` as `RichTextEditor`, matching the editor that's actually used to populate it.
- No schema migration is needed — only metadata changes; the underlying SQL column type (`text`) is unchanged.