### PR TITLE
CSTSPRT-288: Fix Contribution Transfer During Contact Merge

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -377,7 +377,8 @@ class CRM_Dedupe_Merger {
 INNER JOIN  civicrm_pledge_payment payment ON ( payment.contribution_id = contribution.id )
 INNER JOIN  civicrm_pledge pledge ON ( pledge.id = payment.pledge_id )
        SET  contribution.contact_id = $mainContactId
-     WHERE  pledge.contact_id = $otherContactId";
+     WHERE  pledge.contact_id = $otherContactId
+       AND  contribution.contact_id = $otherContactId";
         break;
 
       case 'civicrm_membership':
@@ -386,7 +387,8 @@ INNER JOIN  civicrm_pledge pledge ON ( pledge.id = payment.pledge_id )
 INNER JOIN  civicrm_membership_payment payment ON ( payment.contribution_id = contribution.id )
 INNER JOIN  civicrm_membership membership ON ( membership.id = payment.membership_id )
        SET  contribution.contact_id = $mainContactId
-     WHERE  membership.contact_id = $otherContactId";
+     WHERE  membership.contact_id = $otherContactId
+       AND  contribution.contact_id = $otherContactId";
         break;
 
       case 'civicrm_participant':
@@ -395,7 +397,8 @@ INNER JOIN  civicrm_membership membership ON ( membership.id = payment.membershi
 INNER JOIN  civicrm_participant_payment payment ON ( payment.contribution_id = contribution.id )
 INNER JOIN  civicrm_participant participant ON ( participant.id = payment.participant_id )
        SET  contribution.contact_id = $mainContactId
-     WHERE  participant.contact_id = $otherContactId";
+     WHERE  participant.contact_id = $otherContactId
+       AND  contribution.contact_id = $otherContactId";
         break;
     }
 


### PR DESCRIPTION
## Overview

When two contacts are merged, `civicrm_contribution.contact_id` is currently rewritten to the surviving contact for **every** contribution attached to the deleted contact's participants, memberships, or pledges — regardless of who originally paid. This silently destroys the link between the contribution and its real payer whenever a third party (employer organisation, parent, sibling, friend, anonymous benefactor, etc.) paid on behalf of the contact being merged.

This PR scopes that rewrite to contributions actually paid by the contact being deleted. Third-party-paid contributions now stay attached to their original payer after the merge.

## Before

In `CRM_Dedupe_Merger::paymentSql()`, each of the three `UPDATE` statements (pledge / membership / participant variants) had a `WHERE` clause that filtered only on the bridge entity's `contact_id`:

```sql
UPDATE IGNORE civicrm_contribution contribution
  INNER JOIN civicrm_participant_payment payment ON payment.contribution_id = contribution.id
  INNER JOIN civicrm_participant participant      ON participant.id = payment.participant_id
SET   contribution.contact_id = $mainContactId
WHERE participant.contact_id = $otherContactId
```

Because the `WHERE` only checked who the *participant* was — never who the *payer* was — every contribution attached to the deleted contact's participation got rewritten to the surviving contact, even when that contribution had originally been paid by a different contact entirely.

## After

`paymentSql()` adds `AND contribution.contact_id = $otherContactId` to each WHERE` clause:

```sql
UPDATE IGNORE civicrm_contribution contribution
  INNER JOIN civicrm_participant_payment payment ON payment.contribution_id = contribution.id
  INNER JOIN civicrm_participant participant      ON participant.id = payment.participant_id
SET   contribution.contact_id = $mainContactId
WHERE participant.contact_id  = $otherContactId
  AND contribution.contact_id = $otherContactId
```

Behaviour matrix for the participant case (membership and pledge are
identical in shape):

| participant.contact_id | contribution.contact_id | New WHERE matches? | Result                                |
|------------------------|-------------------------|--------------------|---------------------------------------|
| `otherId`              | `otherId`               | yes                | rewritten to `mainId` (unchanged)     |
| `otherId`              | C (employer org)        | no                 | stays with C ✅ (was incorrectly moved)|
| `otherId`              | parent / sibling / friend | no              | stays with original payer ✅           |
| someone else           | anything                | no                 | not handled by `paymentSql()` (already correct under the bridge filter) |
| `otherId`              | `mainId`                | no                 | left alone (no double-application)    |
