### PR TITLE
COMCL-1463: Fix file display

### DIFF
--- a/templates/CRM/Contact/Page/Inline/CustomDataFieldInstance.tpl
+++ b/templates/CRM/Contact/Page/Inline/CustomDataFieldInstance.tpl
@@ -12,7 +12,7 @@
   {$instance.field_title}
 </div>
 <div class="crm-content crm-custom_data">
-  {if $instance.field_input_type === 'RichTextEditor' || $instance.field_input_type === 'Link'}
+  {if $instance.field_input_type === 'RichTextEditor' || $instance.field_input_type === 'Link' || $instance.field_input_type === 'File'}
     {$instance.field_value|purify nofilter}
   {else}
     {* This would be too strict for some types - eg. contact reference.

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -32,6 +32,8 @@
             <div class="crm-content crm-custom-data crm-contact-reference">
               {$element.contact_ref_links|join:', '}
             </div>
+          {elseif $element.field_type eq 'File' || $element.field_type eq 'RichTextEditor' || $element.field_type === 'Link'}
+            <div class="crm-content crm-custom-data">{$element.field_value|purify}</div>
           {else}
             <div class="crm-content crm-custom-data">{$element.field_value|escape}</div>
           {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the display of custom fields of type 'FILE' on the contact summary screen.

Before
----------------------------------------
<img width="2880" height="2704" alt="image-20260508-134127" src="https://github.com/user-attachments/assets/846933a6-2e62-4712-a6dd-88d09484a03e" />


After
----------------------------------------
<img width="1792" height="1120" alt="Screenshot 2026-05-11 at 2 03 52 PM" src="https://github.com/user-attachments/assets/cd69fc78-1ef9-461b-a304-4db5800a5637" />


Technical Details
----------------------------------------
This was caused by a recent security upgrade by civicrm core and it got fixed later on.