### PR TITLE
COMCL-1463: Fix File Display

### DIFF
--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -32,6 +32,8 @@
             <div class="crm-content crm-custom-data crm-contact-reference">
               {', '|implode:$element.contact_ref_links}
             </div>
+          {elseif $element.field_type eq 'File' || $element.field_type eq 'RichTextEditor' || $element.field_type === 'Link'}
+            <div class="crm-content crm-custom-data">{$element.field_value|purify}</div>
           {else}
             <div class="crm-content crm-custom-data">{$element.field_value|escape}</div>
           {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the display of custom fields of type 'FILE' on the contact summary screen.

Before
----------------------------------------
<img width="2880" height="2704" alt="image-20260508-134127" src="https://github.com/user-attachments/assets/846933a6-2e62-4712-a6dd-88d09484a03e" />


After
----------------------------------------
<img width="1792" height="1120" alt="Screenshot 2026-05-11 at 2 03 52 PM" src="https://github.com/user-attachments/assets/cd69fc78-1ef9-461b-a304-4db5800a5637" />


Technical Details
----------------------------------------
This was caused by a recent security upgrade by civicrm core and it got fixed later on.