### PR TITLE
CIVIMM-525: Fix Boolean CheckBox filter resetting to inactive-only on uncheck

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -291,6 +291,21 @@
         var currentVal = $scope.dataProvider.getFieldData()[ctrl.fieldName];
         // Setter
         if (arguments.length) {
+          // A single Boolean CheckBox transitioning from checked (true) to unchecked in a
+          // search filter context means "remove filter" (null), not "filter for false".
+          // Guards explained:
+          //   - isUserUnchecking: currentVal === true ensures this is a user action, not
+          //     programmatic init from URL params or afform_default where false may be intentional.
+          //   - isSingleBooleanCheckbox: multi-value checkbox lists use checklist-model, not getSetValue.
+          //   - isSearchFilterContext: no af-form ancestor (search filter, not a save form where
+          //     false must persist to DB); no search_operator (field stores value directly,
+          //     not via an operator-keyed object).
+          var isUserUnchecking = val === false && currentVal === true;
+          var isSingleBooleanCheckbox = ctrl.defn.input_type === 'CheckBox' && !ctrl.isMultiple();
+          var isSearchFilterContext = !ctrl.afFieldset.afFormCtrl && !ctrl.search_operator;
+          if (isUserUnchecking && isSingleBooleanCheckbox && isSearchFilterContext) {
+            val = null;
+          }
           if (ctrl.search_operator) {
             if (typeof currentVal !== 'object') {
               $scope.dataProvider.getFieldData()[ctrl.fieldName] = {};


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [CIVIMM-525](https://compucorp.atlassian.net/browse/CIVIMM-525).

In SearchKit searches embedded via Afform, checking and then unchecking a Boolean CheckBox filter (e.g. "Is relationship enabled") incorrectly narrows results to show only inactive records instead of restoring the unfiltered view. Affects CiviCRM 5.75.0 and persists on master.

Before
----------------------------------------
- Page loads (no filter) → 7 relationships shown ✓
- Check "Is relationship enabled" → 4 active-only results ✓
- Uncheck → **only 2 results (inactive-only) — bug**. Filter silently flipped to "inactive only"; no way to recover without page reload.

After
----------------------------------------
- Page loads → 7 results ✓
- Check → 4 results ✓
- Uncheck → 7 results restored, filter fully cleared ✓

Technical Details
----------------------------------------
**Root cause — two-layer chain:**

1. Angular's `ng-model` with `getterSetter: true` calls `getSetValue(false)` when the user unchecks the checkbox.
2. `getAfformFilters()` (and on master, `getFilterValues()` in `afFieldset.directive.js`) treat any `typeof val === 'boolean'` as an active filter — so `false` reaches the API as `is_active=0`.

**Fix** — in `$scope.getSetValue` (`ext/afform/core/ang/af/afField.component.js`), translate `true` → `false` to `null` for single Boolean CheckBox inputs in a search-filter context. Guards ensure save-form behaviour and programmatic-init paths are untouched:

| Guard | Reason |
|---|---|
| `input_type === 'CheckBox' && !isMultiple()` | Single Boolean checkbox only — multi-value checkbox lists use `checklist-model`, not `getSetValue` |
| `currentVal === true` | Distinguishes user uncheck from programmatic `false` set by URL params (`?is_active=0`) or `afform_default: false`, which arrive while `currentVal` is still `undefined` |
| `!ctrl.afFieldset.afFormCtrl` | Limits fix to search-filter fieldsets (no `af-form` ancestor). In save forms `false` must be preserved — `null` would silently skip writing `false` to the database |
| `!ctrl.search_operator` | Field stores value directly; operator-keyed fields follow a different code path and `currentVal` would be an object, not `true` |

Master check
----------------------------------------
**civicrm/civicrm-core master does NOT have this fix** (verified directly):

- `getSetValue` on master still writes raw `val` to `fieldData` on uncheck.
- Master's new `getFilterValues()` filters out `null`/`''`/`[]`/`{}` but explicitly **does not** treat `false` as empty.
- Closest related upstream work is [civicrm/civicrm-core#34172](https://github.com/civicrm/civicrm-core/pull/34172) (merged Dec 2025) where the author explicitly noted: *"I did wonder if we could try to avoid setting these empty values. But an hour pouring through getSetValue and setValue in afField made me think that wasn't at all easy..."* — so they patched the downstream filter layer and left `getSetValue` untouched. This PR takes the next step at the source.

Compliance with the patching process
----------------------------------------
Per [Patching CiviCRM Core](https://compucorp.atlassian.net/wiki/spaces/SD/pages/1546289155/Patching+CiviCRM+Core):

- ✅ Single commit (`73a3563d`)
- ✅ No database changes (schema/default-data untouched)
- ✅ No `tests/` folder changes
- ✅ Targeting `5.75.0-patches` (created from the tag, not master)
- ✅ Commit message follows the [patch-commit format](https://compucorp.atlassian.net/wiki/spaces/SD/pages/1546289212/Patch+commit+example)
- ⏳ **Upstream PR (`civicrm/civicrm-core` master)** — to be opened immediately after this PR is approved internally, per the order @erawat suggested. Once opened, this commit will be amended with the upstream PR URL before "Rebase and merge".
- ⏳ Will register in the [Upstream PR/MR Tracking page](https://compucorp.atlassian.net/wiki/spaces/CT/pages/6091571213/Draft+Upstream+PR+MR+Tracking+Process) once the upstream PR is open, and commit to bi-weekly follow-up until merged.

Testing
----------------------------------------
Environment: CiviCRM 5.75.0 on https://thoroughlyevolvingshad.docker.cc-test.site/civicrm/relationship (`afsearchRelationshipSearch` Afform).

| Step | Before fix | After fix |
|---|---|---|
| Page load (no filter) | 7 results ✓ | 7 results ✓ |
| Check "Is relationship enabled" | 4 active-only results ✓ | 4 active-only results ✓ |
| Uncheck | 2 results ✗ (inactive only — bug) | 7 results ✓ (filter cleared) |

Additional scenarios verified:

| Scenario | Result |
|---|---|
| URL param `?is_active=0` on load | ✓ Guard does not fire (`currentVal` is `undefined`), filter remains active |
| `afform_default: false` | ✓ Guard does not fire (`currentVal` is `undefined`), filter remains active |
| `afform_default: true` → user unchecks | ✓ Guard fires, `null` stored, filter cleared |
| Boolean checkbox on a save form (e.g. `do_not_email`) | ✓ `afFormCtrl` present, guard skipped, `false` written to DB |

**Screenshots:**

*1. Page load, no filter — 7 results*

![Initial state, 7 results](https://raw.githubusercontent.com/compucorp/civicrm-core/media/CIVIMM-525-screenshots/screenshots/01-initial-7-results.png)

*2. Check "Is relationship enabled" — 4 active-only results*

![Checked, 4 results](https://raw.githubusercontent.com/compucorp/civicrm-core/media/CIVIMM-525-screenshots/screenshots/02-checked-4-results.png)

*3. Before fix: uncheck — 2 results (inactive only, bug)*

![Bug: unchecked shows 2 results](https://raw.githubusercontent.com/compucorp/civicrm-core/media/CIVIMM-525-screenshots/screenshots/03-bug-unchecked-2-results.png)

*4. After fix: uncheck — 7 results (filter cleared)*

![Fixed: unchecked shows all 7](https://raw.githubusercontent.com/compucorp/civicrm-core/media/CIVIMM-525-screenshots/screenshots/04-fixed-unchecked-7-results.png)

Screenshots hosted on the `media/CIVIMM-525-screenshots` branch of this repo (kept separate from the PR branch so the patches commit stays single-file).

Comments
----------------------------------------
Reviewers — per [the patching process page](https://compucorp.atlassian.net/wiki/spaces/SD/pages/1546289155/Patching+CiviCRM+Core), please verify:

1. Commit body contains the required information (ticket, description, PR link placeholder pending upstream).
2. No database changes — confirmed.
3. No files outside the tarball distribution (no `tests/` etc.) — confirmed.

Happy to amend the commit with the upstream PR URL as soon as the upstream PR is open.
