### PR TITLE
CIVIMM-525: Fix Boolean CheckBox filter resetting to inactive-only on uncheck

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -291,6 +291,14 @@
         var currentVal = $scope.dataProvider.getFieldData()[ctrl.fieldName];
         // Setter
         if (arguments.length) {
+          // A single Boolean CheckBox transitioning from checked (true) to unchecked in a
+          // search filter context means "remove filter" (null), not "filter for false".
+          const isUserUnchecking = val === false && currentVal === true;
+          const isSingleBooleanCheckbox = ctrl.defn.input_type === 'CheckBox' && !ctrl.isMultiple();
+          const isSearchFilterContext = !ctrl.afFieldset.afFormCtrl && !ctrl.search_operator;
+          if (isUserUnchecking && isSingleBooleanCheckbox && isSearchFilterContext) {
+            val = null;
+          }
           if (ctrl.search_operator) {
             if (typeof currentVal !== 'object') {
               $scope.dataProvider.getFieldData()[ctrl.fieldName] = {};


### PR DESCRIPTION
## Overview

Patch for CiviCRM 5.75.0. Fixes Boolean CheckBox filter in Afform search displays resetting to inactive-only results when unchecked, instead of clearing the filter.

## Upstream PR

https://github.com/civicrm/civicrm-core/pull/35672

## Patching process checklist

- [x] Single commit
- [x] No database changes
- [x] No changes to files excluded from tarball (e.g. tests/)
- [x] Commit message follows patch commit format
- [x] Upstream PR submitted

## Technical Details

In `getSetValue` within `ext/afform/core/ang/af/afField.component.js`, when a single Boolean CheckBox transitions from `true` to `false` in a search-filter context, coerce the value to `null` so the filter is removed rather than inverted.

## Before

Unchecking a Boolean CheckBox filter shows inactive-only results instead of all results.

## After

Unchecking clears the filter and shows all results.