### PR TITLE
MMMM-206: Remove Unnecessary Exception Throw

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -9,8 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Symfony\Component\Finder\Exception\AccessDeniedException;
-
 /**
  *
  * @package CRM
@@ -251,7 +249,6 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    */
   public function permissionDenied() {
     drupal_access_denied();
-    throw new AccessDeniedException();
   }
 
   /**
@@ -851,13 +848,6 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     $profile = str_replace('civicrm/admin/uf/group', $urlReplaceWith, $profile);
 
     return $profile;
-  }
-
-  public function handleUnhandledException(\Throwable $e) {
-    if ($e instanceof AccessDeniedException) {
-      throw $e;
-    }
-    CRM_Core_Error::handleUnhandledException($e);
   }
 
 }


### PR DESCRIPTION
## Overview
----------------------------------------
In [this](https://github.com/compucorp/civicrm-core/pull/168) PR we added an exception throw for access denied scenarios. This was done as a part of security update but it seems it was not needed for drupal7 as that security fix was intended for drupal8 and it was unnecessary for drupal7.

So this PR removes this unwanted exception throw as it needlessly results in an 500 error even after displaying an access denied page to user and increases noise in logs.

This PR does not have any upstream PR as it is just removing some unnecessary changes from the codebase.

## Before
----------------------------------------
Whenever a user visited some page which he does not have access to, in addition to blocking the access an unnecessary exception was also thrown which increased noise in the logs.

## After
----------------------------------------
Now no exception is thrown only access is blocked for above mentioned case.

## Technical Details
----------------------------------------
The access denied exception is not needed for drupal7 as it was added for drupal8 in civicrm core and it was wrongly copied over to our civicrm repo, so now this PR removes it.

