### PR TITLE
MMMM-209: Revert orphaned custom group guard (re-reference to merged upstream)

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1887,12 +1887,6 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       'table_name'
     );
 
-    // Guard against missing tables (e.g. orphaned custom group records
-    // where the backing table was dropped but the group record remains).
-    if (!CRM_Core_DAO::checkTableExists($tableName)) {
-      return TRUE;
-    }
-
     $query = "SELECT count(id) FROM {$tableName} WHERE id IS NOT NULL LIMIT 1";
     $value = CRM_Core_DAO::singleValueQuery($query);
 

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -301,11 +301,6 @@ class TimestampTriggers {
     if ($this->getCustomDataEntity()) {
       $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => $this->getCustomDataEntity(), 'is_multiple' => FALSE]);
       foreach ($customGroups as $customGroup) {
-        // Skip orphaned custom groups whose backing table no longer exists
-        // (e.g. when the last field was deleted but the group record remains).
-        if (!\CRM_Core_DAO::checkTableExists($customGroup['table_name'])) {
-          continue;
-        }
         $relations[] = [
           'table' => $customGroup['table_name'],
           'column' => 'entity_id',


### PR DESCRIPTION
Reverts the MMMM-209 patch commit (`97f18302`) merged in #220.

**Why:** the merged commit references the upstream PR `civicrm/civicrm-core#35504`, which was **closed** (not merged). Upstream landed the fix as a re-roll, **#35574**, in **CiviCRM 6.15.0**. This revert clears the stale-referenced commit so it can be re-applied with the correct `PR:` / `Included in` lines.

Paired re-apply PR (stacked on this branch): re-adds the identical diff with the corrected commit message. Merge this **first**, then the re-apply PR.

- No schema/default-data changes
- Only the 2 PHP files (no `tests/`)
- Rebase and merge