### PR TITLE
MMMM-209: Guard against orphaned custom groups in trigger rebuild and isGroupEmpty

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1887,6 +1887,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       'table_name'
     );
 
+    // Guard against missing tables (e.g. orphaned custom group records
+    // where the backing table was dropped but the group record remains).
+    if (!CRM_Core_DAO::checkTableExists($tableName)) {
+      return TRUE;
+    }
+
     $query = "SELECT count(id) FROM {$tableName} WHERE id IS NOT NULL LIMIT 1";
     $value = CRM_Core_DAO::singleValueQuery($query);
 

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -301,6 +301,11 @@ class TimestampTriggers {
     if ($this->getCustomDataEntity()) {
       $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => $this->getCustomDataEntity(), 'is_multiple' => FALSE]);
       foreach ($customGroups as $customGroup) {
+        // Skip orphaned custom groups whose backing table no longer exists
+        // (e.g. when the last field was deleted but the group record remains).
+        if (!\CRM_Core_DAO::checkTableExists($customGroup['table_name'])) {
+          continue;
+        }
         $relations[] = [
           'table' => $customGroup['table_name'],
           'column' => 'entity_id',


### PR DESCRIPTION
Re-applies the orphaned-custom-group guard with the **corrected upstream reference**.

Identical code to the original #220 (and to merged upstream **civicrm/civicrm-core#35574**, CiviCRM **6.15.0**). The only change vs #220 is the commit message, which now points at the **merged** #35574 instead of the closed #35504:

```
MMMM-209: Guard against orphaned custom groups in trigger rebuild and isGroupEmpty

Included in CiviCRM 6.15.0
PR: https://github.com/civicrm/civicrm-core/pull/35574
```

Stacked on the revert PR #236 — **merge #236 first**, then GitHub will retarget this to `5.75.0-patches`.

- Single commit, cherry-picked from the original
- Uses `CRM_Core_DAO::checkTableExists()` (per-table) rather than the 6.15-only batched `getExistingTables()` helper — necessary adaptation for the 5.75 tag, per the patching playbook
- No schema/default-data changes; only the 2 PHP files (no `tests/`)
- Rebase and merge