### PR TITLE
MMMM-209: Guard against orphaned custom groups in trigger rebuild and isGroupEmpty

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1729,6 +1729,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       'table_name'
     );
 
+    // Guard against missing tables (e.g. orphaned custom group records
+    // where the backing table was dropped but the group record remains).
+    if (!CRM_Core_DAO::checkTableExists($tableName)) {
+      return TRUE;
+    }
+
     $query = "SELECT count(id) FROM {$tableName} WHERE id IS NOT NULL LIMIT 1";
     $value = CRM_Core_DAO::singleValueQuery($query);
 

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -301,6 +301,11 @@ class TimestampTriggers {
     if ($this->getCustomDataEntity()) {
       $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => $this->getCustomDataEntity(), 'is_multiple' => FALSE]);
       foreach ($customGroups as $customGroup) {
+        // Skip orphaned custom groups whose backing table no longer exists
+        // (e.g. when the last field was deleted but the group record remains).
+        if (!\CRM_Core_DAO::checkTableExists($customGroup['table_name'])) {
+          continue;
+        }
         $relations[] = [
           'table' => $customGroup['table_name'],
           'column' => 'entity_id',


### PR DESCRIPTION
Re-applies the guard (identical code to #221 and to merged upstream civicrm/civicrm-core#35574, CiviCRM 6.15.0) with the corrected commit message referencing the **merged** #35574. Single commit. Stacked on the revert PR — merge the revert first; GitHub then retargets this to `6.4.1-patches`. No schema/test files · Rebase and merge.