### PR TITLE
CIVIMM-488: I18n - Add escape=html mode

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -52,8 +52,11 @@ class CRM_Core_I18n {
       case 'js':
         return substr(json_encode($text, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT), 1, -1);
 
+      case 'html':
       case 'htmlattribute':
-        return htmlspecialchars($text, ENT_QUOTES);
+        // Note: the default flags in htmlspecialchars changed from PHP 8.0 to PHP 8.1
+        // Setting them explicitly prevents any PHP-version-specific surprises.
+        return htmlspecialchars($text, ENT_QUOTES | ENT_HTML401);
     }
     throw new Exception('Invalid escape mode: ' . $mode);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Adds new escaping mode for translated strings in Smarty.

Technical Details
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/commit/d1d7d2ade952b5577f2e67f47930b3ad397cf1c2, this adds a 'html' escape mode, which is really no different from 'htmlattribute'.
The only time escaping a html attribute would need extra handling would be if someone forgot to put quotes around it, like <a title={ts}Whoops!{/ts}>, but, well, we don't support that.

Also let's prevent any PHP-version-specific surprises by setting the flags in htmlspecialchars. ENT_HTML401 is the implicit default so let's just add it explicitly.